### PR TITLE
Allow custom 2FA support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ aarlo/
 rsa.*
 diffs
 video_dir
+.idea

--- a/examples/basics
+++ b/examples/basics
@@ -24,6 +24,9 @@ _LOGGER = logging.getLogger('pyaarlo')
 arlo = pyaarlo.PyArlo(username=USERNAME, password=PASSWORD,
                       tfa_type='SMS', tfa_source='console',
                       save_state=False, dump=False, storage_dir='aarlo', verbose_debug=True)
+if not arlo.is_connected:
+    print("failed to login({})".format(arlo._last_error))
+    sys.exit(-1)
 
 print('list bases')
 for base in arlo.base_stations:

--- a/examples/custom-tfa
+++ b/examples/custom-tfa
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#
+
+import logging
+import os
+import sys
+import time
+
+# for examples, import relative to starting path
+sys.path.append('.')
+import pyaarlo
+
+# set these from the environment to log in
+USERNAME = os.environ.get('ARLO_USERNAME', 'test.login@gmail.com')
+PASSWORD = os.environ.get('ARLO_PASSWORD', 'test-password')
+
+# set up logging, change INFO to DEBUG for a *lot* more information
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+_LOGGER = logging.getLogger('pyaarlo')
+
+
+class Arlo2FATest:
+    """ 2FA authentication via console.
+    Accepts input from console and returns that for 2FA.
+    """
+
+    def __init__(self):
+        pass
+
+    def start(self):
+        _LOGGER.debug('2fa-cconsole: starting')
+        return True
+
+    def get(self):
+        _LOGGER.debug('2fa-cconsole: checking')
+        return input('Custom Enter Code: ')
+
+    def stop(self):
+        _LOGGER.debug('2fa-cconsole: stopping')
+
+
+# log in
+# add `verbose_debug=True` to enable even more debugging
+# add `dump=True` to enable event stream packet dumps
+arlo = pyaarlo.PyArlo(username=USERNAME, password=PASSWORD,
+                      tfa_type='SMS', tfa_source=Arlo2FATest(),
+                      save_state=False, dump=False, storage_dir='aarlo', verbose_debug=True)
+
+time.sleep(60)

--- a/examples/inject
+++ b/examples/inject
@@ -29,7 +29,7 @@ arlo = pyaarlo.PyArlo(username=USERNAME, password=PASSWORD,
 
 packet = {
     'action': 'is',
-    'from': '5MJ189WK03543',
+    'from': 'XXXXXXXXXXXXX',
     'properties': [{'blockNotifications': {'block': False,
                                            'duration': 0,
                                            'endTime': 0},
@@ -45,7 +45,7 @@ packet = {
                     'traditionalChimeType': 'digital',
                     'voiceMailEnabled': False}],
     'resource': 'doorbells',
-    'to': '5MJ189WK03543',
+    'to': 'XXXXXXXXXXXXX',
     'transId': '12345'
 }
 

--- a/examples/inject
+++ b/examples/inject
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#
+
+import logging
+import os
+import sys
+
+# for examples, import relative to starting path
+import time
+
+sys.path.append('.')
+import pyaarlo
+
+# set these from the environment to log in
+USERNAME = os.environ.get('ARLO_USERNAME', 'test.login@gmail.com')
+PASSWORD = os.environ.get('ARLO_PASSWORD', 'test-password')
+
+# set up logging, change INFO to DEBUG for a *lot* more information
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+_LOGGER = logging.getLogger('pyaarlo')
+
+# log in
+# add `verbose_debug=True` to enable even more debugging
+# add `dump=True` to enable event stream packet dumps
+arlo = pyaarlo.PyArlo(username=USERNAME, password=PASSWORD,
+                      tfa_type='SMS', tfa_source='console',
+                      save_state=False, dump=False, storage_dir='aarlo', verbose_debug=True)
+
+packet = {
+    'action': 'is',
+    'from': '5MJ189WK03543',
+    'properties': [{'blockNotifications': {'block': False,
+                                           'duration': 0,
+                                           'endTime': 0},
+                    'callLedEnable': True,
+                    'chimes': {},
+                    'liveFeed': True,
+                    'pirLedEnable': True,
+                    'silentMode': {},
+                    'sipCallActive': False,
+                    'states': {},
+                    'traditionalChime': True,
+                    'traditionalChimeDuration': 10000,
+                    'traditionalChimeType': 'digital',
+                    'voiceMailEnabled': False}],
+    'resource': 'doorbells',
+    'to': '5MJ189WK03543',
+    'transId': '12345'
+}
+
+time.sleep(5)
+arlo.inject_response(packet)
+time.sleep(5)

--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -30,6 +30,9 @@ class PyArlo(object):
 
     def __init__(self, **kwargs):
 
+        # core values
+        self._last_error = None
+
         # Set up the config first.
         self._cfg = ArloCfg(self, **kwargs)
 
@@ -45,6 +48,10 @@ class PyArlo(object):
         self._st = ArloStorage(self)
         self._be = ArloBackEnd(self)
         self._ml = ArloMediaLibrary(self)
+
+        # Failed to login, then stop now!
+        if not self._be.is_connected:
+            return
 
         self._lock = threading.Condition()
         self._bases = []
@@ -217,7 +224,7 @@ class PyArlo(object):
 
     @property
     def is_connected(self):
-        return self._be.is_connected()
+        return self._be.is_connected
 
     @property
     def cameras(self):
@@ -278,7 +285,12 @@ class PyArlo(object):
         pass
 
     def error(self, msg):
+        self._last_error = msg
         _LOGGER.error(msg)
+
+    @property
+    def last_error(self):
+        return self._last_error
 
     def warning(self, msg):
         _LOGGER.warning(msg)

--- a/pyaarlo/tfa.py
+++ b/pyaarlo/tfa.py
@@ -3,12 +3,33 @@ import imaplib
 import re
 import time
 
-from .constant import (
-    TFA_CONSOLE_SOURCE,
-    TFA_IMAP_SOURCE)
+
+class Arlo2FAConsole:
+    """ 2FA authentication via console.
+    Accepts input from console and returns that for 2FA.
+    """
+
+    def __init__(self, arlo):
+        self._arlo = arlo
+
+    def start(self):
+        self._arlo.debug('2fa-console: starting')
+        return True
+
+    def get(self):
+        self._arlo.debug('2fa-console: checking')
+        return input('Enter Code: ')
+
+    def stop(self):
+        self._arlo.debug('2fa-console: stopping')
 
 
-class Arlo2FA:
+class Arlo2FAImap:
+    """ 2FA authentication via IMAP
+    Connects to IMAP server and waits for email from Arlo with 2FA code in it.
+
+    Note: will probably need tweaking for other IMAP setups...
+    """
 
     def __init__(self, arlo):
         self._arlo = arlo
@@ -17,90 +38,85 @@ class Arlo2FA:
         self._new_ids = None
 
     def start(self):
-        self._arlo.debug('2fa is using {}'.format(self._arlo.cfg.tfa_source))
+        self._arlo.debug('2fa-imap: starting')
 
-        # console, always works!
-        if self._arlo.cfg.tfa_source == TFA_CONSOLE_SOURCE:
+        # clean up
+        if self._imap is not None:
+            self.stop()
+
+        self._imap = imaplib.IMAP4_SSL(self._arlo.cfg.imap_host)
+        res, status = self._imap.login(self._arlo.cfg.imap_username, self._arlo.cfg.imap_password)
+        if res.lower() != 'ok':
+            self._arlo.debug('imap login failed')
+            return False
+        res, status = self._imap.select()
+        if res.lower() != 'ok':
+            self._arlo.debug('imap select failed')
+            return False
+        res, self._old_ids = self._imap.search(None, 'FROM', 'do_not_reply@arlo.com')
+        if res.lower() != 'ok':
+            self._arlo.debug('imap search failed')
+            return False
+
+        self._new_ids = self._old_ids
+        self._arlo.debug("old-ids={}".format(self._old_ids))
+        if res.lower() == 'ok':
             return True
-
-        # imap, grab snapshot of current IDs
-        elif self._arlo.cfg.tfa_source == TFA_IMAP_SOURCE:
-            self._imap = imaplib.IMAP4_SSL(self._arlo.cfg.imap_host)
-            res, status = self._imap.login(self._arlo.cfg.imap_username, self._arlo.cfg.imap_password)
-            if res.lower() != 'ok':
-                self._arlo.debug('imap login failed')
-                return False
-            res, status = self._imap.select()
-            if res.lower() != 'ok':
-                self._arlo.debug('imap select failed')
-                return False
-            res, self._old_ids = self._imap.search(None, 'FROM', 'do_not_reply@arlo.com')
-            if res.lower() != 'ok':
-                self._arlo.debug('imap search failed')
-                return False
-
-            self._new_ids = self._old_ids
-            self._arlo.debug("old-ids={}".format(self._old_ids))
-            if res.lower() == 'ok':
-                return True
 
         return False
 
     def get(self):
-        self._arlo.debug('2fa checking')
-
-        # console, wait until the user finishes
-        if self._arlo.cfg.tfa_source == TFA_CONSOLE_SOURCE:
-            return input('Enter Code: ')
+        self._arlo.debug('2fa-imap: checking')
 
         # give tfa_total_timeout seconds for email to arrive
-        elif self._arlo.cfg.tfa_source == TFA_IMAP_SOURCE:
+        start = time.time()
+        while True:
 
-            start = time.time()
-            while True:
+            # wait a short while, stop after a total timeout
+            # ok to do on first run gives email time to arrive
+            time.sleep(self._arlo.cfg.tfa_timeout)
+            if time.time() > (start + self._arlo.cfg.tfa_total_timeout):
+                return None
 
-                # wait a short while, stop after a total timeout
-                # ok to do on first run gives email time to arrive
-                time.sleep(self._arlo.cfg.tfa_timeout)
-                if time.time() > (start + self._arlo.cfg.tfa_total_timeout):
-                    return None
+            # grab new email ids
+            self._imap.check()
+            res, self._new_ids = self._imap.search(None, 'FROM', 'do_not_reply@arlo.com')
+            self._arlo.debug("new-ids={}".format(self._new_ids))
+            if self._new_ids == self._old_ids:
+                self._arlo.debug("no change in emails")
+                continue
 
-                # grab new email ids
-                self._imap.check()
-                res, self._new_ids = self._imap.search(None, 'FROM', 'do_not_reply@arlo.com')
-                self._arlo.debug("new-ids={}".format(self._new_ids))
-                if self._new_ids == self._old_ids:
-                    self._arlo.debug("no change in emails")
+            # new message...
+            old_ids = self._old_ids[0].split()
+            for msg_id in self._new_ids[0].split():
+
+                # seen it?
+                if msg_id in old_ids:
                     continue
 
-                # new message...
-                old_ids = self._old_ids[0].split()
-                for msg_id in self._new_ids[0].split():
+                # new message. look for HTML part and look code code in it
+                self._arlo.debug("new-msg={}".format(msg_id))
+                res, msg = self._imap.fetch(msg_id, '(RFC822)')
+                for part in email.message_from_bytes(msg[0][1]).walk():
+                    if part.get_content_type() == 'text/html':
+                        for line in part.get_payload().splitlines():
 
-                    # seen it?
-                    if msg_id in old_ids:
-                        continue
+                            # match code in email, this might need some work if the email changes
+                            code = re.match(r'^\W*(\d{6})\W*$', line)
+                            if code is not None:
+                                self._arlo.debug("code={}".format(code.group(1)))
+                                return code.group(1)
 
-                    # new message. look for HTML part and look code code in it
-                    self._arlo.debug("new-msg={}".format(msg_id))
-                    res, msg = self._imap.fetch(msg_id, '(RFC822)')
-                    for part in email.message_from_bytes(msg[0][1]).walk():
-                        if part.get_content_type() == 'text/html':
-                            for line in part.get_payload().splitlines():
-
-                                # match code in email, this might need some work if the email changes
-                                code = re.match(r'^\W*(\d{6})\W*$', line)
-                                if code is not None:
-                                    self._arlo.debug("code={}".format(code.group(1)))
-                                    return code.group(1)
-
-                # update old so we don't keep trying new
-                self._old_ids = self._new_ids
+            # update old so we don't keep trying new
+            self._old_ids = self._new_ids
 
         return None
 
     def stop(self):
+        self._arlo.debug('2fa-imap: stopping')
 
-        if self._arlo.cfg.tfa_source == TFA_IMAP_SOURCE:
-            self._imap.close()
-            self._imap.logout()
+        self._imap.close()
+        self._imap.logout()
+        self._imap = None
+        self._old_ids = None
+        self._new_ids = None


### PR DESCRIPTION

Allow custom 2FA support. Allows home-assistant flow to work.

Stop immediately after login fails.
