### PR TITLE
Allow video doorbell to not be a base.

### DIFF
--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -166,10 +166,15 @@ class PyArlo(object):
                 self.info('skipping ' + dname + ': state unknown')
                 continue
 
+            # This needs it's own code now... Does no parent indicate a base station???
             if dtype == 'basestation' or \
-                    device.get('modelId') == 'ABC1000' or dtype == 'arloq' or dtype == 'arloqs' or \
-                    device.get('modelId').startswith('AVD1001'):
+                    device.get('modelId') == 'ABC1000' or dtype == 'arloq' or dtype == 'arloqs':
                 self._bases.append(ArloBase(dname, self, device))
+            # video doorbell can be its own base station, it can also be assigned to a real base station
+            if device.get('modelId').startswith('AVD1001'):
+                parent_id = device.get('parentId', None)
+                if parent_id is None or parent_id == device.get('deviceId', None):
+                    self._bases.append(ArloBase(dname, self, device))
             if dtype == 'arlobridge':
                 self._bases.append(ArloBase(dname, self, device))
             if dtype == 'camera' or dtype == 'arloq' or dtype == 'arloqs' or \


### PR DESCRIPTION

Arlo changed it so video doorbell can optionally be a base. Support this.
