### PR TITLE
Add Pro 4 & Essential capabilities

### DIFF
--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -178,7 +178,8 @@ class PyArlo(object):
             # This needs it's own code now... Does no parent indicate a base station???
             if dtype == 'basestation' or \
                     device.get('modelId') == 'ABC1000' or dtype == 'arloq' or dtype == 'arloqs' or \
-                    device.get("modelId").startswith("FB1001A"):
+                    device.get("modelId").startswith("FB1001A") or device.get("modelId").startswith("VMC4041") or \
+                    device.get("modelId").startswith("VMC2030"):
                 self._bases.append(ArloBase(dname, self, device))
             # video doorbell can be its own base station, it can also be assigned to a real base station
             if device.get('modelId').startswith('AVD1001'):

--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -176,13 +176,21 @@ class PyArlo(object):
                 continue
 
             # This needs it's own code now... Does no parent indicate a base station???
-            if dtype == 'basestation' or \
-                    device.get('modelId') == 'ABC1000' or dtype == 'arloq' or dtype == 'arloqs' or \
-                    device.get("modelId").startswith("FB1001A") or device.get("modelId").startswith("VMC4041") or \
-                    device.get("modelId").startswith("VMC2030"):
+            if (
+                dtype == "basestation"
+                or device.get("modelId") == "ABC1000"
+                or dtype == "arloq"
+                or dtype == "arloqs"
+            ):
                 self._bases.append(ArloBase(dname, self, device))
-            # video doorbell can be its own base station, it can also be assigned to a real base station
-            if device.get('modelId').startswith('AVD1001'):
+            # Newer devices can connect directly to wifi and can be its own base station, 
+            # it can also be assigned to a real base station
+            if (
+                device.get("modelId").startswith("AVD1001")
+                or device.get("modelId").startswith("FB1001")
+                or device.get("modelId").startswith("VMC4041") 
+                or device.get("modelId").startswith("VMC2030")
+            ):
                 parent_id = device.get('parentId', None)
                 if parent_id is None or parent_id == device.get('deviceId', None):
                     self._bases.append(ArloBase(dname, self, device))

--- a/pyaarlo/camera.py
+++ b/pyaarlo/camera.py
@@ -1229,15 +1229,15 @@ class ArloCamera(ArloChildDevice):
             return True
         if cap in (AUDIO_DETECTED_KEY,):
             if self.model_id.startswith(
-                    ('VMC4030', 'VMC4040', 'VMC4041', 'VMC5040', 'ABC1000', 'FB1001')):
+                    ('VMC2030', 'VMC4030', 'VMC4040', 'VMC4041', 'VMC5040', 'ABC1000', 'FB1001')):
                 return True
             if self.device_type.startswith('arloq'):
                 return True
         if cap in (SIREN_STATE_KEY,):
-            if self.model_id.startswith(('VMC4040', 'VMC4041', 'VMC5040', 'FB1001')):
+            if self.model_id.startswith(('VMC2030', 'VMC4040', 'VMC4041', 'VMC5040', 'FB1001')):
                 return True
         if cap in (SPOTLIGHT_KEY,):
-            if self.model_id.startswith(('VMC4040', 'VMC4041', 'VMC5040')):
+            if self.model_id.startswith(('VMC2030', 'VMC4040', 'VMC4041', 'VMC5040')):
                 return True
         if cap in (TEMPERATURE_KEY, HUMIDITY_KEY, AIR_QUALITY_KEY):
             if self.model_id.startswith('ABC1000'):
@@ -1250,7 +1250,7 @@ class ArloCamera(ArloChildDevice):
                 return True
         if cap in (CONNECTION_KEY,):
             # These devices are their own base stations so don't re-add connection key.
-            if self.model_id.startswith(('ABC1000', 'FB1001', 'VMC4041')):
+            if self.model_id.startswith(('ABC1000', 'FB1001', 'VMC2030', 'VMC4041')):
                 return False
             if self.device_type in ('arloq', 'arloqs'):
                 return False

--- a/pyaarlo/camera.py
+++ b/pyaarlo/camera.py
@@ -1229,15 +1229,15 @@ class ArloCamera(ArloChildDevice):
             return True
         if cap in (AUDIO_DETECTED_KEY,):
             if self.model_id.startswith(
-                    ('VMC4030', 'VMC4040', 'VMC5040', 'ABC1000', 'FB1001')):
+                    ('VMC4030', 'VMC4040', 'VMC4041', 'VMC5040', 'ABC1000', 'FB1001')):
                 return True
             if self.device_type.startswith('arloq'):
                 return True
         if cap in (SIREN_STATE_KEY,):
-            if self.model_id.startswith(('VMC4040', 'VMC5040', 'FB1001')):
+            if self.model_id.startswith(('VMC4040', 'VMC4041', 'VMC5040', 'FB1001')):
                 return True
         if cap in (SPOTLIGHT_KEY,):
-            if self.model_id.startswith(('VMC4040', 'VMC5040')):
+            if self.model_id.startswith(('VMC4040', 'VMC4041', 'VMC5040')):
                 return True
         if cap in (TEMPERATURE_KEY, HUMIDITY_KEY, AIR_QUALITY_KEY):
             if self.model_id.startswith('ABC1000'):
@@ -1250,7 +1250,7 @@ class ArloCamera(ArloChildDevice):
                 return True
         if cap in (CONNECTION_KEY,):
             # These devices are their own base stations so don't re-add connection key.
-            if self.model_id.startswith(('ABC1000', 'FB1001A')):
+            if self.model_id.startswith(('ABC1000', 'FB1001', 'VMC4041')):
                 return False
             if self.device_type in ('arloq', 'arloqs'):
                 return False


### PR DESCRIPTION
Arlo Pro 4 model id starts with `VMC4041`
Arlo Essential model id starts with `VMC2030`

Pro 4 has the same capabilities as the Pro 3, but with WiFi direct connection so may or may not have a base station.
Essential has the same capabilities as Pro 4 but only a 1080p camera and non-removable battery

twrecked/hass-aarlo#337