### PR TITLE
Fix: Stopping threads after logout

### DIFF
--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -405,6 +405,7 @@ class PyArlo(object):
     def stop(self):
         """Stop connection to Arlo and logout."""
         self._st.save()
+        self._bg._worker.stop()
         self._be.logout()
 
     @property

--- a/pyaarlo/backend.py
+++ b/pyaarlo/backend.py
@@ -47,6 +47,7 @@ class ArloBackEnd(object):
         self._arlo = arlo
         self._lock = threading.Condition()
         self._req_lock = threading.Lock()
+        self._stopThread = False
 
         self._dump_file = self._arlo.cfg.dump_file
 
@@ -408,7 +409,7 @@ class ArloBackEnd(object):
     def _ev_thread_main(self):
 
         self._arlo.debug("starting event loop")
-        while True:
+        while not self._stopThread:
 
             # login again if not first iteration, this will also create a new session
             while not self._logged_in:
@@ -483,6 +484,9 @@ class ArloBackEnd(object):
 
         self._arlo.debug("stream up")
         return True
+    
+    def _ev_stop(self):
+        self._stopThread = True
 
     def _get_tfa(self):
         """Return the 2FA type we're using."""
@@ -763,6 +767,7 @@ class ArloBackEnd(object):
         self._arlo.debug("trying to logout")
         if self._ev_stream is not None:
             self._ev_stream.stop()
+        self._ev_stop()
         self.put(LOGOUT_PATH)
 
     def notify(self, base, body, timeout=None, wait_for=None):

--- a/pyaarlo/background.py
+++ b/pyaarlo/background.py
@@ -26,8 +26,8 @@ class ArloBackgroundWorker(threading.Thread):
 
             # jobs in particular priority
             for run_at, job_id in sorted(self._queue[prio].keys()):
-                if self._stopThread == True:
-                    break
+#                if self._stopThread == True:
+#                    break
                 if run_at <= int(time.monotonic()):
                     job = self._queue[prio].pop((run_at, job_id))
                     self._lock.release()
@@ -66,9 +66,9 @@ class ArloBackgroundWorker(threading.Thread):
                 # loop till done
                 timeout = None
                 while timeout is None:
-                    if self._stopThread == True:
-                        timeout = 0
-                        break
+#                    if self._stopThread == True:
+#                        timeout = 0
+#                        break
                     timeout = self._run_next()
 
                 # wait or get going?

--- a/pyaarlo/background.py
+++ b/pyaarlo/background.py
@@ -10,6 +10,7 @@ class ArloBackgroundWorker(threading.Thread):
         self._id = 0
         self._lock = threading.Condition()
         self._queue = {}
+        self._stopThread = False
 
     def _next_id(self):
         self._id += 1
@@ -25,6 +26,8 @@ class ArloBackgroundWorker(threading.Thread):
 
             # jobs in particular priority
             for run_at, job_id in sorted(self._queue[prio].keys()):
+                if self._stopThread == True:
+                    break
                 if run_at <= int(time.monotonic()):
                     job = self._queue[prio].pop((run_at, job_id))
                     self._lock.release()
@@ -58,11 +61,14 @@ class ArloBackgroundWorker(threading.Thread):
     def run(self):
 
         with self._lock:
-            while True:
+            while not self._stopThread:
 
                 # loop till done
                 timeout = None
                 while timeout is None:
+                    if self._stopThread == True:
+                        timeout = 0
+                        break
                     timeout = self._run_next()
 
                 # wait or get going?
@@ -89,6 +95,9 @@ class ArloBackgroundWorker(threading.Thread):
                         del self._queue[prio][(run_at, job_id)]
                         return True
         return False
+    
+    def stop(self):
+        self._stopThread = True
 
 
 class ArloBackground:


### PR DESCRIPTION
Added a `self._stopThread` boolean in both `ArloBackgroundWorker` and `ArloEventStream` threads and changed the `while True` in both of them to a `while not self._stopThread`. I know that as `daemon` they will terminate with the main thread but if you just want to logout will keeping your main thread active, the threads will keep reconnecting. It's a workaround I made for this issue #71 because in the context I'm working in, I need to be able to logout and stop those threads while keeping my main thread.
@njaouen