### PR TITLE
Mqtt backend

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,4 @@
+0.8.0a12: Use new MQTT backend
 0.8.0a11: Add random user agent support.
 0.8.0a10: Don't request resources for Wirefree doorbells.
 0.8.0a9: Support IMAP port.

--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -40,7 +40,7 @@ from .util import time_to_arlotime
 
 _LOGGER = logging.getLogger("pyaarlo")
 
-__version__ = "0.8.0a11"
+__version__ = "0.8.0a12"
 
 
 class PyArlo(object):
@@ -238,7 +238,10 @@ class PyArlo(object):
         self._st.set(["ARLO", TOTAL_BELLS_KEY], len(self._doorbells))
         self._st.set(["ARLO", TOTAL_LIGHTS_KEY], len(self._lights))
 
-        # Always ping bases first!
+        # Subscribe to events.
+        self._be.start_monitoring()
+
+        # Now ping the bases.
         self._ping_bases()
 
         # Initial config and state retrieval.
@@ -321,7 +324,11 @@ class PyArlo(object):
             if base.has_capability(RESOURCE_CAPABILITY):
                 self._be.notify(
                     base=base,
-                    body={"action": "get", "resource": "cameras", "publishResponse": False},
+                    body={
+                        "action": "get",
+                        "resource": "cameras",
+                        "publishResponse": False,
+                    },
                     wait_for="response",
                 )
                 self._be.notify(
@@ -335,7 +342,11 @@ class PyArlo(object):
                 )
                 self._be.notify(
                     base=base,
-                    body={"action": "get", "resource": "lights", "publishResponse": False},
+                    body={
+                        "action": "get",
+                        "resource": "lights",
+                        "publishResponse": False,
+                    },
                     wait_for="response",
                 )
             else:
@@ -422,6 +433,10 @@ class PyArlo(object):
     @property
     def name(self):
         return "ARLO CONTROLLER"
+
+    @property
+    def devices(self):
+        return self._devices
 
     @property
     def device_id(self):

--- a/pyaarlo/backend.py
+++ b/pyaarlo/backend.py
@@ -2,6 +2,7 @@ import json
 import pickle
 import pprint
 import re
+import ssl
 import threading
 import time
 import traceback
@@ -9,6 +10,7 @@ import uuid
 import random
 
 import cloudscraper
+import paho.mqtt.client as mqtt
 import requests
 import requests.adapters
 
@@ -21,11 +23,12 @@ from .constant import (
     DEFAULT_RESOURCES,
     DEVICES_PATH,
     LOGOUT_PATH,
+    MQTT_HOST,
+    MQTT_PATH,
     NOTIFY_PATH,
     ORIGIN_HOST,
     REFERER_HOST,
     SESSION_PATH,
-    SUBSCRIBE_PATH,
     TFA_CONSOLE_SOURCE,
     TFA_IMAP_SOURCE,
     TFA_PUSH_SOURCE,
@@ -33,7 +36,6 @@ from .constant import (
     TRANSID_PREFIX,
     USER_AGENTS,
 )
-from .sseclient import SSEClient
 from .tfa import Arlo2FAConsole, Arlo2FAImap, Arlo2FARestAPI
 from .util import days_until, now_strftime, time_to_arlotime, to_b64
 
@@ -59,7 +61,10 @@ class ArloBackEnd(object):
 
         self._load_session()
 
-        self._ev_stream = None
+        self._ev_client = None
+        self._ev_thread = None
+        self._ev_connected = False
+        self._stopThread = False
 
         # login
         self._session = None
@@ -67,14 +72,6 @@ class ArloBackEnd(object):
         if not self._logged_in:
             self._arlo.debug("failed to log in")
             return
-
-        # event loop thread - started as needed
-        self._ev_start()
-
-        # start logout daemon
-        if self._arlo.cfg.reconnect_every != 0:
-            self._arlo.debug("automatically reconnecting")
-            self._arlo.bg.run_every(self.logout, self._arlo.cfg.reconnect_every)
 
     def _load_session(self):
         self._user_id = None
@@ -326,95 +323,109 @@ class ArloBackEnd(object):
             for cb in cbs:
                 self._arlo.bg.run(cb, resource=resource, event=response)
 
-    def _ev_loop(self, stream):
+    def _ev_response(self, response):
 
-        # say we're starting
+        # Debugging.
         if self._dump_file is not None:
             with open(self._dump_file, "a") as dump:
                 time_stamp = now_strftime("%Y-%m-%d %H:%M:%S.%f")
-                dump.write("{}: {}\n".format(time_stamp, "ev_loop start"))
-
-        # for event in stream.events():
-        for event in stream:
-
-            # stopped?
-            if event is None:
-                self._arlo.debug("reopening: no event")
-                break
-
-            # dig out response, print out verbose debug
-            try:
-                response = json.loads(event.data)
-            except json.decoder.JSONDecodeError as e:
-                self._arlo.debug("reopening: json error " + str(e))
-                break
-
-            if self._dump_file is not None:
-                with open(self._dump_file, "a") as dump:
-                    time_stamp = now_strftime("%Y-%m-%d %H:%M:%S.%f")
-                    dump.write(
-                        "{}: {}\n".format(
-                            time_stamp, pprint.pformat(response, indent=2)
-                        )
+                dump.write(
+                    "{}: {}\n".format(
+                        time_stamp, pprint.pformat(response, indent=2)
                     )
-            self._arlo.vdebug(
-                "packet-in=\n{}".format(pprint.pformat(response, indent=2))
-            )
+                )
+        self._arlo.vdebug(
+            "packet-in=\n{}".format(pprint.pformat(response, indent=2))
+        )
 
-            # logged out? signal exited
-            if response.get("action") == "logout":
-                self._arlo.warning("logged out? did you log in from elsewhere?")
-                break
+        # Logged out? MQTT will log back in until stopped.
+        if response.get("action") == "logout":
+            self._arlo.warning("logged out? did you log in from elsewhere?")
+            return
 
-            # connected - yay!
-            if response.get("status") == "connected":
-                with self._lock:
-                    self._ev_connected_ = True
+        # Run the dispatcher to set internal state and run callbacks.
+        self._ev_dispatcher(response)
+
+        # is there a notify/post waiting for this response? If so, signal to waiting entity.
+        tid = response.get("transId", None)
+        resource = response.get("resource", None)
+        device_id = response.get("from", None)
+        with self._lock:
+            # Transaction ID
+            # Simple. We have a transaction ID, look for that. These are
+            # usually returned by notify requests.
+            if tid and tid in self._requests:
+                self._requests[tid] = response
+                self._lock.notify_all()
+
+            # Resource
+            # These are usually returned after POST requests. We trap these
+            # to make async calls sync.
+            if resource:
+                # Historical. We are looking for a straight matching resource.
+                if resource in self._requests:
+                    self._arlo.vdebug("{} found by text!".format(resource))
+                    self._requests[resource] = response
                     self._lock.notify_all()
-                continue
 
-            # Run the dispatcher to set internal state and run callbacks.
-            self._ev_dispatcher(response)
+                else:
+                    # Complex. We are looking for a resource and-or
+                    # deviceid matching a regex.
+                    if device_id:
+                        resource = "{}:{}".format(resource, device_id)
+                        self._arlo.vdebug("{} bounded device!".format(resource))
+                    for request in self._requests:
+                        if re.match(request, resource):
+                            self._arlo.vdebug(
+                                "{} found by regex {}!".format(resource, request)
+                            )
+                            self._requests[request] = response
+                            self._lock.notify_all()
 
-            # is there a notify/post waiting for this response? If so, signal to waiting entity.
-            tid = response.get("transId", None)
-            resource = response.get("resource", None)
-            device_id = response.get("from", None)
-            with self._lock:
-                # Transaction ID
-                # Simple. We have a transaction ID, look for that. These are
-                # usually returned by notify requests.
-                if tid and tid in self._requests:
-                    self._requests[tid] = response
-                    self._lock.notify_all()
+    def mqtt_subscribe(self):
+        # Make sure we are listening to library events and individual base
+        # station events. This seems sufficient for now.
+        self._ev_client.subscribe([
+            (f"u/{self._user_id}/in/userSession/connect", 0),
+            (f"u/{self._user_id}/in/userSession/disconnect", 0),
+            (f"u/{self._user_id}/in/library/add", 0),
+            (f"u/{self._user_id}/in/library/update", 0),
+            (f"u/{self._user_id}/in/library/remove", 0)
+        ])
 
-                # Resource
-                # These are usually returned after POST requests. We trap these
-                # to make async calls sync.
-                if resource:
-                    # Historical. We are looking for a straight matching resource.
-                    if resource in self._requests:
-                        self._arlo.vdebug("{} found by text!".format(resource))
-                        self._requests[resource] = response
-                        self._lock.notify_all()
-                    else:
-                        # Complex. We are looking for a resource and-or
-                        # deviceid matching a regex.
-                        if device_id:
-                            resource = "{}:{}".format(resource, device_id)
-                            self._arlo.vdebug("{} bounded device!".format(resource))
-                        for request in self._requests:
-                            if re.match(request, resource):
-                                self._arlo.vdebug(
-                                    "{} found by regex {}!".format(resource, request)
-                                )
-                                self._requests[request] = response
-                                self._lock.notify_all()
+        topics = []
+        for device in self._arlo.devices:
+            for topic in device.get("allowedMqttTopics", []):
+                topics.append((topic, 0))
+        self._arlo.debug("topcs=\n{}".format(pprint.pformat(topics)))
+        self._ev_client.subscribe(topics)
+
+    def mqtt_on_connect(self, _client, _userdata, _flags, rc):
+        # Subscribing in on_connect() means that if we lose the connection and
+        # reconnect then subscriptions will be renewed.
+        self._arlo.debug(f"mqtt: connected={str(rc)}")
+        self.mqtt_subscribe()
+        with self._lock:
+            self._ev_connected = True
+            self._lock.notify_all()
+
+    def mqtt_on_log(self, _client, _userdata, _level, msg):
+        self._arlo.vdebug(f"mqtt: log={str(msg)}")
+
+    def mqtt_on_message(self, _client, _userdata, msg):
+        self._arlo.debug(f"mqtt: topic={msg.topic}")
+        response = json.loads(msg.payload.decode("utf-8"))
+        self._ev_response(response)
 
     def _ev_thread_main(self):
 
-        self._arlo.debug("starting event loop")
         while not self._stopThread:
+
+            # Say we're starting
+            if self._dump_file is not None:
+                with open(self._dump_file, "a") as dump:
+                    time_stamp = now_strftime("%Y-%m-%d %H:%M:%S.%f")
+                    dump.write("{}: {}\n".format(time_stamp, "ev_loop start"))
 
             # login again if not first iteration, this will also create a new session
             while not self._logged_in:
@@ -423,38 +434,34 @@ class ArloBackEnd(object):
                 self._arlo.debug("re-logging in")
                 self._logged_in = self._login()
 
-            # get stream, restart after requested seconds of inactivity or forced close
             try:
-                if self._arlo.cfg.stream_timeout == 0:
-                    self._arlo.debug("starting stream with no timeout")
-                    # self._ev_stream = SSEClient( self.get( SUBSCRIBE_PATH + self._token,stream=True,raw=True ) )
-                    self._ev_stream = SSEClient(
-                        self._arlo,
-                        self._arlo.cfg.host + SUBSCRIBE_PATH,
-                        session=self._session,
-                        reconnect_cb=self._ev_reconnected,
-                    )
-                else:
-                    self._arlo.debug(
-                        "starting stream with {} timeout".format(
-                            self._arlo.cfg.stream_timeout
-                        )
-                    )
-                    # self._ev_stream = SSEClient(
-                    #     self.get(SUBSCRIBE_PATH + self._token, stream=True, raw=True,
-                    #              timeout=self._arlo.cfg.stream_timeout))
-                    self._ev_stream = SSEClient(
-                        self._arlo,
-                        self._arlo.cfg.host + SUBSCRIBE_PATH,
-                        session=self._session,
-                        reconnect_cb=self._ev_reconnected,
-                        timeout=self._arlo.cfg.stream_timeout,
-                    )
-                self._ev_loop(self._ev_stream)
-            except requests.exceptions.ConnectionError:
-                self._arlo.warning("event loop timeout")
-            except AttributeError as e:
-                self._arlo.warning("forced close " + str(e))
+                self._arlo.debug("(re)starting event loop")
+                headers = {
+                    "Host": MQTT_HOST,
+                    "Origin": ORIGIN_HOST,
+                }
+
+                # Build a new client_id per login. The last 10 numbers seem to need to be random.
+                self._ev_client_id = f"user_{self._user_id}_" + "".join(
+                    str(random.randint(0, 9)) for _ in range(10)
+                )
+                self._arlo.debug(f"mqtt: client_id={self._ev_client_id}")
+
+                # Create and setup the MQTT client.
+                self._ev_client = mqtt.Client(
+                    client_id=self._ev_client_id, transport="websockets"
+                )
+                self._ev_client.on_log = self.mqtt_on_log
+                self._ev_client.on_connect = self.mqtt_on_connect
+                self._ev_client.on_message = self.mqtt_on_message
+                self._ev_client.tls_set_context(ssl.create_default_context())
+                self._ev_client.username_pw_set(f"{self._user_id}", self._token)
+                self._ev_client.ws_set_options(path=MQTT_PATH, headers=headers)
+
+                # Connect.
+                self._ev_client.connect(MQTT_HOST, port=443, keepalive=60)
+                self._ev_client.loop_forever()
+
             except Exception as e:
                 # self._arlo.warning('general exception ' + str(e))
                 self._arlo.error(
@@ -463,19 +470,14 @@ class ArloBackEnd(object):
                     )
                 )
 
-            # clear down and signal out
-            with self._lock:
-                self._ev_connected_ = False
-                self._requests = {}
-                self._lock.notify_all()
-
-            # restart login...
-            self._ev_stream = None
+            # Restart login... This may not be completely necessary.
+            self._client = None
+            self._ev_connected = False
             self._logged_in = False
 
-    def _ev_start(self):
-        self._ev_stream = None
-        self._ev_connected_ = False
+    def start_monitoring(self):
+        self._ev_client = None
+        self._ev_connected = False
         self._ev_thread = threading.Thread(
             name="ArloEventStream", target=self._ev_thread_main, args=()
         )
@@ -483,7 +485,7 @@ class ArloBackEnd(object):
 
         with self._lock:
             self._ev_thread.start()
-            if not self._ev_connected_:
+            if not self._ev_connected:
                 self._arlo.debug("waiting for stream up")
                 self._lock.wait(30)
 
@@ -770,9 +772,9 @@ class ArloBackEnd(object):
 
     def logout(self):
         self._arlo.debug("trying to logout")
-        if self._ev_stream is not None:
-            self._ev_stream.stop()
         self._ev_stop()
+        if self._ev_client is not None:
+            self._ev_client.disconnect()
         self.put(LOGOUT_PATH)
 
     def notify(self, base, body, timeout=None, wait_for=None):

--- a/pyaarlo/camera.py
+++ b/pyaarlo/camera.py
@@ -201,33 +201,35 @@ class ArloCamera(ArloChildDevice):
 
         # Always make this the latest thumbnail image.
         if self._snapshot_time < date:
-            self._arlo.debug("updating image for " + self.name)
             self._snapshot_time = date
             date = date.strftime(self._arlo.cfg.last_format)
+            self._arlo.debug(f"updating image for {self.name} ({date})")
             self._save_and_do_callbacks(LAST_IMAGE_SRC_KEY, "capture/" + date)
             self._save_and_do_callbacks(LAST_CAPTURE_KEY, date)
             self._save_and_do_callbacks(LAST_IMAGE_DATA_KEY, img)
         else:
-            self._arlo.vdebug("ignoring image for " + self.name)
+            date = date.strftime(self._arlo.cfg.last_format)
+            self._arlo.vdebug(f"ignoring image for {self.name} ({date})")
 
     # Update the last snapshot
-    def _update_snapshot(self):
+    def _update_snapshot(self, ignore_date=False):
         # Get image and date, if fails ignore.
-        img, date = http_get_img(self._load(SNAPSHOT_KEY, None))
+        img, date = http_get_img(self._load(SNAPSHOT_KEY, None), ignore_date)
         if img is None:
             self._arlo.debug("failed to load snapshot for " + self.name)
             return
 
         # Always make this the latest snapshot image.
         if self._snapshot_time < date:
-            self._arlo.debug("updating snapshot for " + self.name)
             self._snapshot_time = date
             date = date.strftime(self._arlo.cfg.last_format)
+            self._arlo.debug(f"updating snapshot for {self.name} ({date})")
             self._save_and_do_callbacks(LAST_IMAGE_SRC_KEY, "snapshot/" + date)
             self._save_and_do_callbacks(LAST_IMAGE_DATA_KEY, img)
             self._stop_snapshot()
         else:
-            self._arlo.vdebug("ignoring snapshot for " + self.name)
+            date = date.strftime(self._arlo.cfg.last_format)
+            self._arlo.vdebug(f"ignoring snapshot for {self.name} ({date})")
 
     def _set_recent(self, timeo):
         with self._lock:
@@ -374,7 +376,7 @@ class ArloCamera(ArloChildDevice):
                         "{} -> snapshot(thumbnail) ready".format(self.name)
                     )
                     self._save(SNAPSHOT_KEY, event.get(LAST_IMAGE_KEY, ""))
-                    self._arlo.bg.run_low(self._update_snapshot)
+                    self._arlo.bg.run_low(self._update_snapshot, ignore_date=True)
 
             # Recording has stopped so a new video is available. Queue an
             # media update, this could later trigger a snapshot or image

--- a/pyaarlo/cfg.py
+++ b/pyaarlo/cfg.py
@@ -98,10 +98,7 @@ class ArloCfg(object):
 
     @property
     def snapshot_checks(self):
-        checks = self._kw.get("snapshot_checks", [])
-        if not checks:
-            return [1, 5]
-        return checks
+        return self._kw.get("snapshot_checks", [])
 
     @property
     def user_agent(self):

--- a/pyaarlo/constant.py
+++ b/pyaarlo/constant.py
@@ -2,8 +2,9 @@ DEFAULT_HOST = "https://myapi.arlo.com"
 
 ORIGIN_HOST = "https://my.arlo.com"
 REFERER_HOST = "https://my.arlo.com/"
+MQTT_HOST = "mqtt-cluster.arloxcld.com"
 
-DEVICES_PATH = "/hmsweb/users/devices"
+DEVICES_PATH = "/hmsweb/v2/users/devices"
 DEFINITIONS_PATH = "/hmsweb/users/automation/definitions"
 AUTOMATION_PATH = "/hmsweb/users/devices/automation/active"
 LIBRARY_PATH = "/hmsweb/users/library"
@@ -20,6 +21,7 @@ RESTART_PATH = "/hmsweb/users/devices/restart"
 STREAM_SNAPSHOT_PATH = "/hmsweb/users/devices/takeSnapshot"
 STREAM_START_PATH = "/hmsweb/users/devices/startStream"
 IDLE_SNAPSHOT_PATH = "/hmsweb/users/devices/fullFrameSnapshot"
+MQTT_PATH = "/mqtt"
 TRANSID_PREFIX = "web"
 
 DEFAULT_AUTH_HOST = "https://ocapi-app.arlo.com"

--- a/pyaarlo/util.py
+++ b/pyaarlo/util.py
@@ -91,18 +91,21 @@ def http_get(url, filename=None):
     return True
 
 
-def http_get_img(url):
+def http_get_img(url, ignore_date=False):
     """Download HTTP image data."""
 
     ret = _http_get(url)
     if ret is None:
-        return None, datetime.now()
+        return None, datetime.now().astimezone()
 
-    date = ret.headers.get("Last-Modified", None)
-    if date is not None:
-        date = httptime_to_datetime(date)
-    else:
-        date = datetime.now()
+    date = None
+    if not ignore_date:
+        date = ret.headers.get("Last-Modified", None)
+        if date is not None:
+            date = httptime_to_datetime(date)
+    if date is None:
+        date = datetime.now().astimezone()
+
     return ret.content, date
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ click
 pycryptodome
 unidecode
 cloudscraper>=1.2.58
+paho-mqtt

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readme():
 setup(
 
     name='pyaarlo',
-    version='0.8.0a11',
+    version='0.8.0a12',
     packages=['pyaarlo'],
 
     python_requires='>=3.6',
@@ -20,7 +20,8 @@ setup(
         'click',
         'pycryptodome',
         'unidecode',
-        'cloudscraper>=1.2.58'
+        'cloudscraper>=1.2.58',
+        'paho-mqtt'
     ],
 
     author='Steve Herrell',


### PR DESCRIPTION
Arlo now uses mqtt for the backend to the webclient. This change uses the new back end for event handing.

The code, for now, uses the RESTAPI for controlling the devices.
