### PR TITLE
Add Support For Base Station Media Downloads with RATLS

### DIFF
--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -341,6 +341,7 @@ class PyArlo(object):
     def _refresh_bases(self, initial):
         for base in self._bases:
             base.update_modes(initial)
+            base.keep_ratls_open()
             if base.has_capability(RESOURCE_CAPABILITY):
                 self._be.notify(
                     base=base,

--- a/pyaarlo/backend.py
+++ b/pyaarlo/backend.py
@@ -831,17 +831,18 @@ class ArloBackEnd(object):
             trans_id = self.gen_trans_id()
 
         body["to"] = base.device_id
-        body["from"] = self._web_id
+        if not "from" in body:
+            body["from"] = self._web_id
         body["transId"] = trans_id
 
-        if (
-            self.post(
-                NOTIFY_PATH + base.device_id, body, headers={"xcloudId": base.xcloud_id}
-            )
-            is None
-        ):
+        response = self.post(
+            NOTIFY_PATH + base.device_id, body, headers={"xcloudId": base.xcloud_id}
+        )
+
+        if response is None:
             return None
-        return trans_id
+        else:
+            return trans_id
 
     def _start_transaction(self, tid=None):
         if tid is None:

--- a/pyaarlo/base.py
+++ b/pyaarlo/base.py
@@ -29,9 +29,10 @@ from .constant import (
 )
 from .device import ArloDevice
 from .util import time_to_arlotime
+from .media import ArloBaseStationMediaLibrary
+from .ratls import ArloRatls
 
 day_of_week = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su", "Mo"]
-
 
 class ArloBase(ArloDevice):
     def __init__(self, name, arlo, attrs):
@@ -39,6 +40,7 @@ class ArloBase(ArloDevice):
         self._refresh_rate = 15
         self._schedules = None
         self._last_update = 0
+        self._ratls = None
 
     def _id_to_name(self, mode_id):
         return self._load([MODE_ID_TO_NAME_KEY, mode_id], None)
@@ -501,3 +503,23 @@ class ArloBase(ArloDevice):
                 return False
             return True
         return super().has_capability(cap)
+
+    def build_ratls(self, public=False):
+        self._ratls = ArloRatls(self._arlo, self, public=public)
+
+    def keep_ratls_open(self):
+        if self._ratls:
+            self._arlo.debug("refreshing ratls for {}".format(self.name))
+            self._ratls.open_port()
+
+    def build_media_library(self):
+        self._ml = ArloBaseStationMediaLibrary(self._arlo, self)
+        self._ml.load()
+
+    @property
+    def ml(self):
+        return self._ml
+
+    @property
+    def ratls(self):
+        return self._ratls

--- a/pyaarlo/constant.py
+++ b/pyaarlo/constant.py
@@ -21,6 +21,12 @@ RESTART_PATH = "/hmsweb/users/devices/restart"
 STREAM_SNAPSHOT_PATH = "/hmsweb/users/devices/takeSnapshot"
 STREAM_START_PATH = "/hmsweb/users/devices/startStream"
 IDLE_SNAPSHOT_PATH = "/hmsweb/users/devices/fullFrameSnapshot"
+CREATE_DEVICE_CERTS_PATH = "/hmsweb/users/devices/v2/security/cert/create"
+RATLS_TOKEN_GENERATE_PATH = "/hmsweb/users/device/ratls/token"
+RATLS_CONNECTIVITY_PATH = '/hmsls/connectivity'
+RATLS_DOWNLOAD_PATH = "/hmsls/download"
+RATLS_LIBRARY_PATH = "/hmsls/list" # Supports list/{YYYYMMDD}/{YYYYMMMDD} or list/{YYYYMMDD}/{YYYYMMMDD}/{device_id}
+
 MQTT_PATH = "/mqtt"
 TRANSID_PREFIX = "web"
 
@@ -233,6 +239,8 @@ BLANK_IMAGE = (
     "tivOs6f/QsrFAAAAAElFTkSuQmCC"
 )
 
+VIDEO_CONTENT_TYPES = ['2k', '4k', 'hd']
+
 # DEFAULT_MODES = [ { u'id':u'mode0',u'type':u'disarmed' }, { u'id':u'mode1',u'type':u'armed' } ]
 DEFAULT_MODES = {"disarmed": "mode0", "armed": "mode1"}
 DEFAULT_RESOURCES = {"modes", "siren", "doorbells", "lights", "cameras", "devices"}
@@ -274,3 +282,6 @@ USER_AGENTS = {
         "Mozilla/5.0 (X11; Linux x86_64) "
         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36"
 }
+
+CERT_BEGIN = '-----BEGIN CERTIFICATE-----\n'
+CERT_END = '-----END CERTIFICATE-----\n'

--- a/pyaarlo/media.py
+++ b/pyaarlo/media.py
@@ -3,7 +3,12 @@ import threading
 from datetime import datetime, timedelta
 from string import Template
 
-from .constant import LIBRARY_PATH
+from .constant import (
+    LIBRARY_PATH,
+    RATLS_LIBRARY_PATH,
+    RATLS_DOWNLOAD_PATH,
+    VIDEO_CONTENT_TYPES
+)
 from .util import arlotime_strftime, arlotime_to_datetime, http_get, http_stream
 
 
@@ -14,6 +19,7 @@ class ArloMediaDownloader(threading.Thread):
         self._save_format = save_format
         self._lock = threading.Condition()
         self._queue = []
+        self._downloading = False
 
     # noinspection PyPep8Naming
     def _output_name(self, media):
@@ -74,7 +80,7 @@ class ArloMediaDownloader(threading.Thread):
                 # Download to temporary file before renaming it.
                 self._arlo.debug(f"dowloading for {media.camera.name} --> {save_file}")
                 save_file_tmp = f"{save_file}.tmp"
-                http_get(media.url, save_file_tmp)
+                media.download_video(save_file_tmp)
                 os.rename(save_file_tmp, save_file)
                 return 1
             else:
@@ -83,7 +89,7 @@ class ArloMediaDownloader(threading.Thread):
                 )
                 return 0
         except OSError as _e:
-            self._arlo.error(f"failed to dowload: {save_file}")
+            self._arlo.error(f"failed to download: {save_file}")
             return -1
 
     def run(self):
@@ -96,11 +102,13 @@ class ArloMediaDownloader(threading.Thread):
             with self._lock:
                 if len(self._queue) > 0:
                     media = self._queue.pop(0)
+                    self._downloading = True
 
             if media is not None:
                 result = self._download(media)
 
             with self._lock:
+                self._downloading = False
                 # Nothing else to do then just wait.
                 if len(self._queue) == 0:
                     self._arlo.vdebug(f"waiting for media")
@@ -117,6 +125,10 @@ class ArloMediaDownloader(threading.Thread):
             if len(self._queue) == 1:
                 self._lock.notify()
 
+    @property
+    def processing(self):
+        with self._lock:
+            return len(self._queue) > 0 or self._downloading
 
 class ArloMediaLibrary(object):
     """Arlo Library Media module implementation."""
@@ -129,6 +141,7 @@ class ArloMediaLibrary(object):
         self._videos = []
         self._video_keys = []
         self._snapshots = {}
+        self._base = None
 
         self._downloader = ArloMediaDownloader(arlo, self._arlo.cfg.save_media_to)
         self._downloader.name = "ArloMediaDownloader"
@@ -138,15 +151,18 @@ class ArloMediaLibrary(object):
     def __repr__(self):
         return "<{0}:{1}>".format(self.__class__.__name__, self._arlo.cfg.name)
 
+    def _fetch_library(self, date_from, date_to):
+        return self._arlo.be.post(
+            LIBRARY_PATH, {"dateFrom": date_to, "dateTo": date_to}
+        )
+
     # grab recordings from last day, add to existing library if not there
     def update(self):
         self._arlo.debug("updating image library")
 
         # grab today's images
         date_to = datetime.today().strftime("%Y%m%d")
-        data = self._arlo.be.post(
-            LIBRARY_PATH, {"dateFrom": date_to, "dateTo": date_to}
-        )
+        data = self._fetch_library(date_to, date_to)
 
         # get current videos
         with self._lock:
@@ -171,8 +187,10 @@ class ArloMediaLibrary(object):
                     )
                 continue
 
+            content_type = video.get("contentType", "")
+
             # videos, add missing
-            if video.get("contentType", "").startswith("video/"):
+            if content_type.startswith("video/") or content_type in VIDEO_CONTENT_TYPES :
                 key = "{0}:{1}".format(
                     camera.device_id, arlotime_strftime(video.get("utcCreatedDate"))
                 )
@@ -180,7 +198,7 @@ class ArloMediaLibrary(object):
                     self._arlo.vdebug(f"skipping {key} for {camera.name}")
                     continue
                 self._arlo.debug(f"adding {key} for {camera.name}")
-                video = ArloVideo(video, camera, self._arlo)
+                video = ArloVideo(video, camera, self._arlo, self._base)
                 videos.append(video)
                 self._downloader.queue_download(video)
                 keys.append(key)
@@ -209,9 +227,8 @@ class ArloMediaLibrary(object):
         self._arlo.debug("loading image library ({} days)".format(days))
 
         # save videos for cameras we know about
-        data = self._arlo.be.post(
-            LIBRARY_PATH, {"dateFrom": date_from, "dateTo": date_to}
-        )
+        data = self._fetch_library(date_from, date_to)
+
         if data is None:
             self._arlo.warning("error loading the image library")
             return
@@ -241,13 +258,14 @@ class ArloMediaLibrary(object):
                 continue
 
             # videos, add all
-            if video.get("contentType", "").startswith("video/"):
+            content_type = video.get("contentType", "")
+            if content_type.startswith("video/") or content_type in VIDEO_CONTENT_TYPES:
                 key = "{0}:{1}".format(
                     video.get("deviceId"),
                     arlotime_strftime(video.get("utcCreatedDate")),
                 )
                 self._arlo.vdebug(f"adding {key} for {camera.name}")
-                video = ArloVideo(video, camera, self._arlo)
+                video = ArloVideo(video, camera, self._arlo, self._base)
                 videos.append(video)
                 self._downloader.queue_download(video)
                 keys.append(key)
@@ -290,15 +308,35 @@ class ArloMediaLibrary(object):
                 self._arlo.bg.run_low_in(self.update, 2)
             self._load_cbs_.append(cb)
 
+class ArloBaseStationMediaLibrary(ArloMediaLibrary):
+    """Arlo Media Library for Base Stations"""
+    def __init__(self, arlo, base):
+        super().__init__(arlo)
+        self._base = base
+
+    def _fetch_library(self, date_from, date_to):
+        list = []
+
+        # Fetch each page individually, since the base station still only return results for one date at a time
+        for date in range(int(date_from), int(date_to) + 1):
+            for camera in self._arlo.cameras:
+                if camera.parent_id == self._base.device_id:
+                    # This URL is mysterious -- it won't return multiple days of videos
+                    data = self._base.ratls.get(f"{RATLS_LIBRARY_PATH}/{date}/{date}/{camera.device_id}")
+                    if data and "data" in data:
+                        list += data["data"]
+
+        return list
 
 class ArloMediaObject(object):
     """Object for Arlo Video file."""
 
-    def __init__(self, attrs, camera, arlo):
+    def __init__(self, attrs, camera, arlo, base):
         """Video Object."""
         self._arlo = arlo
         self._attrs = attrs
         self._camera = camera
+        self._base = base
 
     def __repr__(self):
         """Representation string of object."""
@@ -349,6 +387,8 @@ class ArloMediaObject(object):
     def extension(self):
         if self.content_type.endswith("mp4"):
             return "mp4"
+        if self.content_type in VIDEO_CONTENT_TYPES:
+            return "mp4"
         return "jpg"
 
     @property
@@ -376,9 +416,9 @@ class ArloMediaObject(object):
 class ArloVideo(ArloMediaObject):
     """Object for Arlo Video file."""
 
-    def __init__(self, attrs, camera, arlo):
+    def __init__(self, attrs, camera, arlo, base):
         """Video Object."""
-        super().__init__(attrs, camera, arlo)
+        super().__init__(attrs, camera, arlo, base)
 
     @property
     def media_duration_seconds(self):
@@ -404,19 +444,50 @@ class ArloVideo(ArloMediaObject):
         return self._attrs.get("presignedContentUrl", None)
 
     def download_video(self, filename=None):
-        return http_get(self.video_url, filename)
+        video_url = self.video_url
+
+        if (self._base):
+            video_url = f"{RATLS_DOWNLOAD_PATH}/{video_url}"
+
+            response = self._base.ratls.get(video_url, raw=True)
+
+            if response is None:
+                return False
+
+            with open(filename, "wb") as data:
+                data.write(response.read())
+
+            return True
+        else:
+
+            return http_get(video_url, filename)
+
+    @property
+    def created_at(self):
+        """Returns date video was creaed, adjusted to ms"""
+        timestamp = super().created_at
+        if self._base:
+            if timestamp:
+                return timestamp * 1000
+            return None
+        return timestamp
 
     @property
     def stream_video(self):
-        return http_stream(self.video_url)
-
+        if self._base:
+            response = self._base.ratls.get(f"{RATLS_DOWNLOAD_PATH}/{self.video_url}", raw=True)
+            response.raise_for_status()
+            for data in response.iter_content(4096):
+                yield data
+        else:
+            http_stream(self.video_url)
 
 class ArloSnapshot(ArloMediaObject):
     """Object for Arlo Snapshot file."""
 
-    def __init__(self, attrs, camera, arlo):
+    def __init__(self, attrs, camera, arlo, base):
         """Snapshot Object."""
-        super().__init__(attrs, camera, arlo)
+        super().__init__(attrs, camera, arlo, base)
 
     @property
     def image_url(self):

--- a/pyaarlo/ratls.py
+++ b/pyaarlo/ratls.py
@@ -1,0 +1,161 @@
+import ssl
+import json
+import os
+from urllib.request import Request, build_opener, HTTPSHandler
+import requests
+from .security_utils import SecurityUtils
+
+from .constant import (
+    RATLS_CONNECTIVITY_PATH,
+    RATLS_TOKEN_GENERATE_PATH,
+    CREATE_DEVICE_CERTS_PATH
+)
+
+class ArloRatls(object):
+    def __init__(self, arlo, base, public=False):
+        self._arlo = arlo
+        self._base = base
+        self._public = public
+        self._unique_id = base.unique_id
+        self._device_id = base.device_id
+        self._security = SecurityUtils(arlo.cfg.storage_dir)
+
+        self._check_device_certs()
+        self.open_port()
+
+    def open_port(self):
+        """ RATLS port will automatically close after 10 minutes """
+        self._base_station_token = self._get_station_token()
+
+        self._arlo.debug(f"Opening port for {self._unique_id}")
+
+        response = self._arlo.be.notify(
+            self._base,
+            {
+                "action": "open",
+                "resource": "storage/ratls",
+                "from": self._base.user_id,
+                "publishResponse": True
+            },
+            wait_for="event"
+        )
+
+        if response is None or not response['success']:
+            raise Exception(f"Failed to open ratls port: {response}")
+
+        self._base_connection_details = response['properties']
+        self._setup_base_client()
+
+        response = self.get(RATLS_CONNECTIVITY_PATH)
+        if response is None or not response['success']:
+            raise Exception(f"Failed to gain connectivity to ratls!")
+
+        return self._base_connection_details
+
+    def get(self, path, raw=False):
+        request = Request(f"{self.url}{path}")
+        request.get_method = lambda: 'GET'
+
+        for (k, v) in self._ratls_req_headers().items():
+            request.add_header(k, v)
+
+        try:
+            response = self._base_client.open(request)
+            if raw:
+                return response
+            return json.loads(response.read())
+        except Exception as e:
+            self._arlo.warning("request-error={}".format(type(e).__name__))
+            return None
+
+    def _ratls_req_headers(self):
+      return {
+          "Authorization": f"Bearer {self._base_station_token}",
+          "Accept": "application/json; charset=utf-8;",
+          "Accept-Language": "en-US,en;q=0.9",
+          "Origin": "https://my.arlo.com",
+          "SchemaVersion": "1",
+          "User-Agent": self._arlo.be.user_agent(self._arlo.cfg.user_agent)
+      }
+
+    def _get_station_token(self):
+        """ Tokens expire after 10 minutes """
+        self._arlo.debug(f"Fetching token for {self._device_id}")
+
+        response = self._arlo.be.get(
+            RATLS_TOKEN_GENERATE_PATH + f"/{self._device_id}"
+        )
+
+        if response is None or not 'ratlsToken' in response:
+            raise Exception(f"Failed get station token: {response}")
+
+        return response['ratlsToken']
+
+    def _setup_base_client(self):
+        certs_path = self._security.certs_path
+        device_certs_path = self._security.device_certs_path(self._unique_id)
+        self._sslcontext = ssl.create_default_context(cafile=os.path.join(certs_path, "ica.crt"))
+
+        # We are providing certs for the base station to trust us
+        self._sslcontext.load_cert_chain(os.path.join(device_certs_path, "peer.crt"), self._security.private_key_path)
+
+        # ... but we cannot validate the base station's certificate
+        self._sslcontext.check_hostname = False
+        self._sslcontext.verify_mode = ssl.CERT_NONE
+
+        self._base_client = build_opener(HTTPSHandler(context=self._sslcontext))
+
+    def _check_device_certs(self):
+        self._arlo.debug(f"Checking for existing certificates for {self._unique_id}")
+
+        if not self._security.has_device_certs(self._unique_id):
+            response = self._arlo.be.post(
+                CREATE_DEVICE_CERTS_PATH,
+                params={
+                    "uuid": self._device_id,
+                    "uniqueIds": [
+                        self._unique_id
+                    ],
+                    "publicKey": self._security.public_key.replace("\n", "").replace("-----BEGIN PUBLIC KEY-----", "").replace("-----END PUBLIC KEY-----", ""),
+                },
+                headers={"xcloudId": self._base.xcloud_id},
+                raw=True
+            )
+
+            if not response["success"]:
+                raise Exception(f"Error getting certs: {response['message']} - {response['reason']}")
+
+            self._arlo.debug(f"Saving certificates for {self._unique_id}")
+
+            self._security.save_device_certs(self._unique_id, response["data"])
+
+    @property
+    def security(self):
+        return self._security
+
+    @property
+    def url(self):
+        if self._public:
+            return self.publicUrl
+        else:
+            return self.privateUrl
+
+    @property
+    def privateIp(self):
+        return self._base_connection_details['privateIP']
+
+    @property
+    def publicIp(self):
+        return self._base_connection_details['publicIP']
+
+    @property
+    def port(self):
+        return self._base_connection_details['port']
+
+    @property
+    def privateUrl(self):
+        return f"https://{self.privateIp}:{self.port}"
+
+    @property
+    def publicUrl(self):
+        return f"https://{self.publicIp}:{self.port}"

--- a/pyaarlo/security_utils.py
+++ b/pyaarlo/security_utils.py
@@ -1,0 +1,101 @@
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.backends import default_backend
+
+import os
+import textwrap
+
+from .constant import CERT_BEGIN, CERT_END
+
+class SecurityUtils(object):
+  def __init__(self, storage_dir: str) -> None:
+    self.__storage_dir = storage_dir
+    self.__private_key: str = None
+    self.__public_key: str = None
+    if not self.__load_keys():
+      self.__generate_keypair()
+
+  @property
+  def public_key(self) -> str:
+    if self.__public_key is None:
+      self.__generate_keypair()
+    return self.__public_key
+
+  @property
+  def private_key(self) -> str:
+    if self.__private_key is None:
+      self.__generate_keypair()
+    return self.__private_key
+
+  @property
+  def public_key_path(self) -> str:
+    return os.path.join(self.__storage_dir, "certs", "public.pem")
+
+  @property
+  def private_key_path(self) -> str:
+    return os.path.join(self.__storage_dir, "certs", "private.pem")
+
+  def __load_keys(self) -> bool:
+    if os.path.exists(self.private_key_path) and os.path.exists(self.public_key_path):
+      self.__private_key = open(self.private_key_path).read()
+      self.__public_key = open(self.public_key_path).read()
+      return True
+    return False
+
+
+  def __generate_keypair(self):
+    # generate private/public key pair
+    key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, \
+        key_size=2048)
+
+    # get private key in PEM container format
+    pem = key.private_bytes(encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption())
+
+    pub_pem = key.public_key().public_bytes(encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo)
+
+    # decode to printable strings
+    self.__private_key = pem.decode('utf-8')
+    self.__public_key = pub_pem.decode('utf-8')
+
+    os.makedirs(os.path.join(self.__storage_dir, "certs"), exist_ok=True)
+
+    with open(self.public_key_path, "w") as public_key_file:
+      public_key_file.write(self.__public_key)
+    with open(self.private_key_path, "w") as private_key_file:
+      private_key_file.write(self.__private_key)
+
+  @property
+  def certs_path(self) -> str:
+    return os.path.join(self.__storage_dir, "certs")
+
+  def device_certs_path(self, base_station_id: str) -> str:
+    return os.path.join(self.__storage_dir, "certs", base_station_id)
+
+  def has_device_certs(self, base_station_id: str) -> bool:
+    return os.path.exists(os.path.join(self.device_certs_path(base_station_id), "peer.crt"))
+
+  def save_device_certs(self, base_station_id: str, certs):
+    device_cert = certs['certsData'][0]["deviceCert"]
+    peer_cert = certs["certsData"][0]["peerCert"]
+    ica_cert = certs["icaCert"]
+
+    device_cert = textwrap.fill(device_cert, width=64) + '\n'
+    peer_cert = textwrap.fill(peer_cert, width=64) + '\n'
+    ica_cert = textwrap.fill(ica_cert, width=64) + '\n'
+
+    os.makedirs(os.path.join(self.device_certs_path(base_station_id)), exist_ok=True)
+
+    with open(os.path.join(self.device_certs_path(base_station_id), "device.crt"), 'w') as device_file:
+      device_file.writelines([CERT_BEGIN, device_cert, CERT_END])
+
+    with open(os.path.join(self.device_certs_path(base_station_id), "peer.crt"), 'w') as peer_file:
+      peer_file.writelines([CERT_BEGIN, peer_cert, CERT_END])
+
+    with open(os.path.join(self.__storage_dir, "certs", "ica.crt"), 'w') as ica_file:
+      ica_file.writelines([CERT_BEGIN, ica_cert, CERT_END])
+
+    with open(os.path.join(self.device_certs_path(base_station_id), "combined.crt"), 'w') as combined_file:
+      combined_file.writelines([CERT_BEGIN, peer_cert, CERT_END, CERT_BEGIN, ica_cert, CERT_END])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pycryptodome
 unidecode
 cloudscraper>=1.2.58
 paho-mqtt
+cryptography


### PR DESCRIPTION
Follow-up to #86 and based on work done [here](https://github.com/jesserockz/python-arlo-ratls-poc) by @jesserockz 

This adds some new classes:
  * ArloRatls - Triggers base station port opening, token issuance, and client TLS against the base station.
  * ArloBaseStationMediaLibrary - Subclass of ArloMediaLibrary which can iterate over the base station library and trigger downloads of videos
  * SecurityUtils - A near-exact copy of @jesserockz 's library for managing the creation of certificates and management of certificates signed for each device.
 

Example usage:

```python
  for station in arlo.base_stations:
    print(f"Connecting to base station {station.name}: {station.device_id}")
    station.build_ratls()

    print(f"Downloading media from {station.name}...")
    station.build_media_library()

    time.sleep(2)
    while(len(station.ml._downloader._queue) > 0):
      time.sleep(2)
```
