### PR TITLE
Better stopping.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,4 @@
+0.8.0b2: Better shutdown of threads.
 0.8.0b1: Fix yahoo imap support.
   Fix creation of ArloSnapshot objects.
 

--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -40,7 +40,7 @@ from .util import time_to_arlotime
 
 _LOGGER = logging.getLogger("pyaarlo")
 
-__version__ = "0.8.0b1"
+__version__ = "0.8.0b2"
 
 
 class PyArlo(object):
@@ -441,7 +441,8 @@ class PyArlo(object):
     def stop(self):
         """Stop connection to Arlo and logout."""
         self._st.save()
-        self._bg._worker.stop()
+        self._bg.stop()
+        self._ml.stop()
         self._be.logout()
 
     @property

--- a/pyaarlo/background.py
+++ b/pyaarlo/background.py
@@ -92,7 +92,10 @@ class ArloBackgroundWorker(threading.Thread):
         return False
     
     def stop(self):
-        self._stopThread = True
+        with self._lock:
+            self._stopThread = True
+            self._lock.notify()
+        self.join(10)
 
 
 class ArloBackground:
@@ -145,3 +148,6 @@ class ArloBackground:
     def cancel(self, to_delete):
         if to_delete is not None:
             self._worker.stop_job(to_delete)
+
+    def stop(self):
+        self._worker.stop()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readme():
 setup(
 
     name='pyaarlo',
-    version='0.8.0b1',
+    version='0.8.0b2',
     packages=['pyaarlo'],
 
     python_requires='>=3.6',


### PR DESCRIPTION
Tidy up stopping:
 - add stop() method to ArloBackground
 - add stop() method to ArloMediaLibrary

Arlo.stop() will now call these stopping threads which can be helpful on long running systems.
