### PR TITLE
Add event id and time to URLs

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
 0.8.0b4: Allow ping when devices are on chargers.
+  Added event_id and time to URL paths.
 0.8.0b3: Better snapshot tidy up.
   Improve debugging - add component or ID to debug entry.
   Allow actual user agent to be used by prefixing with a !

--- a/pyaarlo/backend.py
+++ b/pyaarlo/backend.py
@@ -151,7 +151,7 @@ class ArloBackEnd(object):
             with self._req_lock:
                 if host is None:
                     host = self._arlo.cfg.host
-                url = host + path
+                url = self._add_extra_params(host + path)
                 self.vdebug("request-url={}".format(url))
                 self.vdebug("request-params=\n{}".format(pprint.pformat(params)))
                 self.vdebug(
@@ -214,6 +214,15 @@ class ArloBackEnd(object):
 
     def gen_trans_id(self, trans_type=TRANSID_PREFIX):
         return trans_type + "!" + str(uuid.uuid4())
+
+    def _add_extra_params(self, url):
+        if '?' in url:
+            url = url + '&'
+        else:
+            url = url + '?'
+        eid = str(uuid.uuid4())
+        now = time_to_arlotime()
+        return f"{url}event_id=FE!{eid}&time={now}"
 
     def _event_dispatcher(self, response):
 


### PR DESCRIPTION
Make URL match latest Arlo web site requests.
