### PR TITLE
Work in progress - Add manual page

### DIFF
--- a/docs/pyaarlo.1
+++ b/docs/pyaarlo.1
@@ -4,13 +4,13 @@ pyaarlo \- List devices, perform simple actions and anonymize/encrypt logs for d
 .SH SYNOPSIS
 \fBpyaarlo [OPTIONS] COMMAND [ARGS]...\fR
 .SH DESCRIPTION
-pyaarlo is a Python module to manage Aarlo cameras. \fBpyaarlo\fR executable perform simple actions.
+pyaarlo is a Python module to manage Aarlo cameras. The \fBpyaarlo\fR executable performs simple actions.
 
 This manual page is for the \fBpyaarlo\fR executable. The Python module documentation is available in \fI/usr/share/doc/python3-pyaarlo/README.md.gz\fR.
 
 .SS COMMANDS
 
-Help specific for each command is available executing \fBpyaarlo COMMAND --help\fR.
+Help specific to each command is available by executing \fBpyaarlo COMMAND --help\fR.
 
 .TP
 \fBanonymize\fR
@@ -20,7 +20,7 @@ cat output-file | pyaarlo -u username -p password anonymize
 
 .TP
 \fBcamera\fR
-Start, stop or take thumbnails from the camera. Requires an argument from {start-stream|stop-stream|last-thumbnail}. Example:
+Start or stop the camera, or take thumbnails. Requires an argument from {start-stream|stop-stream|last-thumbnail}. For example:
 .IP
 pyaarlo -u username -p password camera last-thumbnail
 
@@ -32,7 +32,7 @@ cat encrypted | pyaarlo decrypt
 
 .TP
 \fBdump\fR
-Print out everything that was returned from Arlo about the devices in the system.
+Print out everything that was returned from Arlo about the devices in the system. For example:
 .IP
 pyaarlo dump all
 
@@ -44,7 +44,7 @@ cat output-file | pyaarlo encrypt
 
 .TP
 \fBlist\fR
-Requires an argument from {all|cameras|bases|lights|doorbells}. Example:
+Requires an argument from {all|cameras|bases|lights|doorbells}. For example:
 .IP
 pyaarlo -u username -p password list all
 
@@ -83,11 +83,11 @@ Pass phrase for private key.
 
 .TP
 \fB-s, --storage-dir TEXT\fR.
-Where to store Arlo state and packet dump [default: (current dir)]
+Where to store Aarlo state and packet dump [default: (current dir)]
 
 .TP
 \fB-w, --wait / --no-wait\fR.
-Wait for all information to arrive starting up.
+Wait for all information to arrive on start-up.
 
 .TP
 \fB-v, --verbose\fR.

--- a/docs/pyaarlo.1
+++ b/docs/pyaarlo.1
@@ -1,0 +1,97 @@
+.TH PYAARLO 1
+.SH NAME
+pyaarlo \- List devices, perform simple actions and anonymize/encrypt logs for debugging
+.SH SYNOPSIS
+\fBpyaarlo [OPTIONS] COMMAND [ARGS]...\fR
+.SH DESCRIPTION
+pyaarlo is a Python module to manage Aarlo cameras. \fBpyaarlo\fR executable perform simple actions.
+
+This manual page is for the \fBpyaarlo\fR executable. The Python module documentation is in \fI/usr/share/doc/python3-pyaarlo/README.md.gz\fR.
+
+.SS COMMANDS
+
+.TP
+\fBanonymize\fR
+Anonymize and encrypt logs for debugging purposes. For example:
+.IP
+cat output-file | pyaarlo -u 'your-user-name' -p 'your-password' anonymize
+
+.TP
+\fBcamera\fR
+pyaarlo camera --help
+
+For the details of this action.
+
+.TP
+\fBdecrypt\fR
+For example:
+.IP
+cat encrypted | pyaarlo decrypt
+
+.TP
+\fBdump\fR
+
+.TP
+\fBencrypt\fR
+For example:
+.IP
+cat output-file | pyaarlo encrypt
+
+.SS
+\fBlist\fR
+Needs an option from {all, cameras, bases, lights, doorbells}.
+
+.SS OPTIONS
+.TP
+\fB-u, --username TEXT\fR
+Aarlo username.
+
+.TP
+\fB-p, --password TEXT\fR
+Aarlo password.
+
+.TP
+\fB-a, --anonymize / --no-anonymize\fR
+Anonymize ids.
+
+.TP
+\fB-c, --compact / --no-compact\fR
+Minimize lists.
+
+.TP
+\fB-e, --encrypt / --no-encrypt\fR
+Where possible, encrypt output.
+
+.TP
+\fB-k, --public-key TEXT\fR
+Public key for encryption.
+
+.TP
+\fB-K, --private-key TEXT\fR
+Private key for decryption.
+
+.TP
+\fB-P, --pass-phrase TEXT\fR
+Pass phrase for private key.
+
+.TP
+\fB-s, --storage-dir TEXT\fR.
+Where to store Arlo state and packet dump [default: (current dir)]
+
+.TP
+\fB-w, --wait / --no-wait\fR.
+Wait for all information to arrive starting up.
+
+.TP
+\fB-v, --verbose\fR.
+Be chatty. More is more chatty!
+
+.TP
+\fB--help\fR.
+Show help message and exit.
+
+.SH AUTHOR
+This manual page was written by Carles Pina i Estany <carles@pina.cat> for the \fBDebian\fR system (but may be used by others). Permission is granted to copy, distribute and/or modify this document under the terms of the GNU General Public License, Version 3 any later version published by the Free Software Foundation.
+
+Full documentation in \fI/usr/share/doc/python3-pyaarlo/README.md.gz\fP
+

--- a/docs/pyaarlo.1
+++ b/docs/pyaarlo.1
@@ -6,40 +6,47 @@ pyaarlo \- List devices, perform simple actions and anonymize/encrypt logs for d
 .SH DESCRIPTION
 pyaarlo is a Python module to manage Aarlo cameras. \fBpyaarlo\fR executable perform simple actions.
 
-This manual page is for the \fBpyaarlo\fR executable. The Python module documentation is in \fI/usr/share/doc/python3-pyaarlo/README.md.gz\fR.
+This manual page is for the \fBpyaarlo\fR executable. The Python module documentation is available in \fI/usr/share/doc/python3-pyaarlo/README.md.gz\fR.
 
 .SS COMMANDS
+
+Help specific for each command is available executing \fBpyaarlo COMMAND --help\fR.
 
 .TP
 \fBanonymize\fR
 Anonymize and encrypt logs for debugging purposes. For example:
 .IP
-cat output-file | pyaarlo -u 'your-user-name' -p 'your-password' anonymize
+cat output-file | pyaarlo -u username -p password anonymize
 
 .TP
 \fBcamera\fR
-pyaarlo camera --help
-
-For the details of this action.
+Start, stop or take thumbnails from the camera. Requires an argument from {start-stream|stop-stream|last-thumbnail}. Example:
+.IP
+pyaarlo -u username -p password camera last-thumbnail
 
 .TP
 \fBdecrypt\fR
-For example:
+Decrypt from stdin. For example:
 .IP
 cat encrypted | pyaarlo decrypt
 
 .TP
 \fBdump\fR
+Print out everything that was returned from Arlo about the devices in the system.
+.IP
+pyaarlo dump all
 
 .TP
 \fBencrypt\fR
-For example:
+Encrypt from stdin. For example:
 .IP
 cat output-file | pyaarlo encrypt
 
-.SS
+.TP
 \fBlist\fR
-Needs an option from {all, cameras, bases, lights, doorbells}.
+Requires an argument from {all|cameras|bases|lights|doorbells}. Example:
+.IP
+pyaarlo -u username -p password list all
 
 .SS OPTIONS
 .TP
@@ -84,7 +91,7 @@ Wait for all information to arrive starting up.
 
 .TP
 \fB-v, --verbose\fR.
-Be chatty. More is more chatty!
+More vebose with multiple -v.
 
 .TP
 \fB--help\fR.
@@ -93,5 +100,6 @@ Show help message and exit.
 .SH AUTHOR
 This manual page was written by Carles Pina i Estany <carles@pina.cat> for the \fBDebian\fR system (but may be used by others). Permission is granted to copy, distribute and/or modify this document under the terms of the GNU General Public License, Version 3 any later version published by the Free Software Foundation.
 
-Full documentation in \fI/usr/share/doc/python3-pyaarlo/README.md.gz\fP
+.SH SEE ALSO
+Full Pyaarlo full documentation <https://pyaarlo.readthedocs.io/en/latest/> or available locally in </usr/share/doc/python3-pyaarlo/README.md.gz>.
 


### PR DESCRIPTION
I am packaging pyaarlo for Debian, so it will be available using `apt` on Debian and Ubuntu.

For doing this I need to write a manual page for any executable (like `pyaarlo`). I've started one in this MR. It's not finished but it would be great if an improved version of this could be part of this repository instead of being part of the Debian package only (it's usually better maintained by upstream repository than the Debian maintainer).

I've done it in groff straight ahead (the original manual language).

I am struggling a bit with the "pyaarlo dump". I don't have any Aarlo camera so I cannot test it - if a description could be provided it would be great. Otherwise, tomorrow, when I continue, I'll work something out.

As said: this is a draft and not finished but I thought that might be useful and perhaps @twrecked can improve before I have time.