### PR TITLE
Use "python3" instead of "python"

### DIFF
--- a/bin/pyaarlo
+++ b/bin/pyaarlo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/examples/archive
+++ b/examples/archive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 
 import logging

--- a/examples/async-snapshot
+++ b/examples/async-snapshot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 
 import logging

--- a/examples/basics
+++ b/examples/basics
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 
 import logging

--- a/examples/custom-tfa
+++ b/examples/custom-tfa
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 
 import logging

--- a/examples/inject
+++ b/examples/inject
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 
 import logging

--- a/examples/monitor-all
+++ b/examples/monitor-all
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 
 import logging

--- a/pyaarlo/main.py
+++ b/pyaarlo/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 
 import base64


### PR DESCRIPTION
When packaging for Debian I got a (pedantic) lintian information that examples/ used a non-usual interpreter. This fixes it.

I can solve it without this PR, just sending it because might be good generally speaking and not only for the Debian package. Feel free to discard it!