### PR TITLE
Add slugify to setup.py's dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
         'unidecode',
         'cloudscraper>=1.2.71',
         'paho-mqtt',
-        'cryptography'
+        'cryptography',
+        'slugify'
     ],
 
     author='Steve Herrell',


### PR DESCRIPTION
Without this, it's missed when installing with e.g. pip and causes import errors.