### PR TITLE
Fix AttributeError in update_mode when API returns None

### DIFF
--- a/pyaarlo/location.py
+++ b/pyaarlo/location.py
@@ -155,6 +155,9 @@ class ArloLocation(ArloSuper):
         """Check and update the base's current mode."""
         data = self._arlo.be.get(LOCATION_ACTIVEMODE_PATH_FORMAT.format(self._id),
                                  headers=self._extra_headers())
+        if data is None:
+            self._arlo.error("failed to read active mode.")
+            return
         mode_id = data.get("properties", {}).get('mode')
         mode_revision = data.get("revision")
         self._save_and_do_callbacks(MODE_KEY, mode_id)


### PR DESCRIPTION
## Summary
When the Arlo API returns `None` from the active mode endpoint, `update_mode()` crashes with an `AttributeError` because it calls `.get()` on `None`. This causes a tight error loop that consumes excessive CPU.

## Problem
```
AttributeError: 'NoneType' object has no attribute 'get'
  File "pyaarlo/location.py", line 158, in update_mode
    mode_id = data.get("properties", {}).get('mode')
```

This can happen when:
- The Arlo API is temporarily unavailable
- Network issues cause a failed request
- The API returns an unexpected response

## Solution
Add a `None` check before accessing `data`, consistent with the existing pattern used in `update_modes()` just below this function.

## Testing
- Tested with pyaarlo 0.8.0.17
- Verified the fix prevents the error loop when the API returns None
- Normal operation unaffected when API returns valid data