### PR TITLE
Fix stop() leaving ghost threads that block reconnection

### DIFF
--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -487,12 +487,23 @@ class PyArlo(object):
             self._lock.notify_all()
 
     def stop(self, logout=False):
-        """Stop connection to Arlo and, optionally, logout."""
+        """Stop connection to Arlo and, optionally, logout.
+
+        Always stops the background worker, media library, and event stream
+        thread. If logout=True, also sends a logout request to the Arlo API
+        to invalidate the session.
+
+        Must be called before creating a new PyArlo instance in the same
+        process, otherwise ghost threads from the old instance will interfere
+        with the new connection. See https://github.com/twrecked/pyaarlo/issues/71
+        """
         self._st.save()
         self._bg.stop()
         self._ml.stop()
         if logout:
             self._be.logout()
+        else:
+            self._be.stop()
 
     @property
     def entity_id(self):

--- a/pyaarlo/backend.py
+++ b/pyaarlo/backend.py
@@ -482,6 +482,8 @@ class ArloBackEnd(object):
 
     def _event_stop_loop(self):
         self._stop_thread = True
+        with self._lock:
+            self._lock.notify_all()
 
     def _event_main(self):
         self.debug("re-logging in")
@@ -495,9 +497,11 @@ class ArloBackEnd(object):
                     dump.write("{}: {}\n".format(time_stamp, "event_thread start"))
 
             # login again if not first iteration, this will also create a new session
-            while not self._logged_in:
+            while not self._logged_in and not self._stop_thread:
                 with self._lock:
                     self._lock.wait(5)
+                if self._stop_thread:
+                    break
                 self.debug("re-logging in")
                 self._logged_in = self._login()
 
@@ -1159,14 +1163,31 @@ class ArloBackEnd(object):
     def is_connected(self):
         return self._logged_in
 
-    def logout(self):
-        self.debug("trying to logout")
+    def stop(self):
+        """Stop the event stream thread and wait for it to exit.
+
+        Without this, dropping a PyArlo reference leaves ghost threads
+        that hold stale connections and attempt their own re-logins,
+        interfering with any new PyArlo instance in the same process.
+        See https://github.com/twrecked/pyaarlo/issues/71
+        """
+        self.debug("stopping backend")
         self._event_stop_loop()
         if self._event_client is not None:
-            if self._use_mqtt:
-                self._event_client.disconnect()
-            else:
-                self._event_client.stop()
+            try:
+                if self._use_mqtt:
+                    self._event_client.disconnect()
+                else:
+                    self._event_client.stop()
+            except Exception:
+                pass
+        if self._event_thread is not None and self._event_thread.is_alive():
+            self._event_thread.join(timeout=10)
+
+    def logout(self):
+        """Stop the event stream and log out of the Arlo API."""
+        self.debug("trying to logout")
+        self.stop()
         self.put(LOGOUT_PATH)
 
     def notify(self, base, body, timeout=None, wait_for=None):


### PR DESCRIPTION
## Summary

Fixes #71.

When `stop()` is called, the backend event stream thread keeps running — it holds stale SSE/MQTT connections and attempts its own re-logins, making it impossible to create a new `PyArlo` instance in the same process. The only recovery is killing the entire process.

**Three bugs contributed:**

1. **`PyArlo.stop()` never stops the backend** — it only calls `self._be.logout()` when `logout=True`. With the default `logout=False`, the event stream thread is never stopped.

2. **The re-login loop ignores the stop flag** — `_event_main()` has `while not self._logged_in` without checking `_stop_thread`. Once the event stream drops, the thread enters an infinite re-login loop that cannot be interrupted by `stop()`.

3. **`_event_stop_loop()` doesn't wake blocked threads** — it sets the flag but doesn't call `notify_all()`, so threads blocked on `self._lock.wait(5)` don't see it for up to 5 seconds.

## Changes

- Add `ArloBackEnd.stop()` — signals the event thread, disconnects the MQTT/SSE client, and joins the thread with a 10s timeout
- Update `PyArlo.stop()` to always call `self._be.stop()` (or `.logout()` when `logout=True`)
- Check `_stop_thread` in the re-login loop so stop requests are honoured immediately
- Call `self._lock.notify_all()` in `_event_stop_loop()` to wake blocked threads

## Motivation

Any long-running application that needs to reconnect to Arlo (e.g. Home Assistant, or any polling service) hits this — after the session goes stale, creating a new `PyArlo` instance in the same process fails because the old instance's ghost threads compete for the same Arlo account, triggering Cloudflare 403/500 blocks. The standard workaround has been to restart the entire process, but proper cleanup in `stop()` makes in-process reconnection work reliably.

## Test plan

- [ ] Call `arlo.stop()` then verify `ArloBackgroundWorker` and `ArloEventStream` threads are no longer alive
- [ ] Call `arlo.stop(logout=True)` then create a new `PyArlo()` in the same process — should connect cleanly
- [ ] Call `arlo.stop()` while the event thread is in the re-login loop — thread should exit promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)