### PR TITLE
fix: support V3 custom modes and location-based alarm panel

### DIFF
--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -417,6 +417,8 @@ class PyArlo(object):
             base.update_modes(initial)
             base.keep_ratls_open()
             base.update_states()
+        for location in self._locations:
+            location.update_modes(initial)
 
     def _refresh_modes(self):
         self.vdebug("refresh modes")

--- a/pyaarlo/base.py
+++ b/pyaarlo/base.py
@@ -145,8 +145,15 @@ class ArloBase(ArloDevice):
     def _event_handler(self, resource, event):
         self.debug(self.name + " BASE got " + resource)
 
+        # V3: feedNotification carries activeMode name — update MODE_KEY so
+        # hass-aarlo can reflect the correct state in the alarm control panel.
+        if resource == "feedNotification":
+            active_mode = event.get("activeMode", None)
+            if active_mode:
+                self._save_and_do_callbacks(MODE_KEY, active_mode)
+
         # modes on base station
-        if resource == "modes":
+        elif resource == "modes":
             props = event.get("properties", {})
 
             # list of modes - recheck?
@@ -154,11 +161,11 @@ class ArloBase(ArloDevice):
 
             # mode change?
             if "activeMode" in props:
-                self._save_and_do_callbacks(
-                    MODE_KEY, self._id_to_name(props["activeMode"])
-                )
+                mode_name = self._id_to_name(props["activeMode"])
+                self._save_and_do_callbacks(MODE_KEY, mode_name)
             elif "active" in props:
-                self._save_and_do_callbacks(MODE_KEY, self._id_to_name(props["active"]))
+                mode_name = self._id_to_name(props["active"])
+                self._save_and_do_callbacks(MODE_KEY, mode_name)
 
         # Base station mode change.
         # These come in per device and can arrive multiple times per state
@@ -260,7 +267,16 @@ class ArloBase(ArloDevice):
         :param mode_name: mode to use, as returned by available_modes:
         """
         if self._v3_modes:
-            self._arlo.debug(f"BaseStations don't have modes in v3")
+            # In V3, modes are managed at the location level — delegate to the
+            # corresponding location. gatewayDeviceIds may include a userId prefix
+            # (e.g. "userId_deviceId"), so we match by suffix.
+            for location in self._arlo.locations:
+                for gid in location.device_ids:
+                    if gid == self.device_id or gid.endswith("_" + self.device_id):
+                        self.debug(f"V3: delegating mode={mode_name} to location {location.name}")
+                        location.mode = mode_name
+                        return
+            self._arlo.debug(f"V3: no location found for base {self.device_id}, ignoring mode change")
             return
 
         # Actually passed a mode?

--- a/pyaarlo/constant.py
+++ b/pyaarlo/constant.py
@@ -30,6 +30,7 @@ RATLS_LIBRARY_PATH = "/hmsls/list"  # Supports list/{YYYYMMDD}/{YYYYMMMDD} or li
 
 LOCATIONS_PATH_FORMAT = "/hmsdevicemanagement/users/{0}/locations"  # {0} is _user_id
 LOCATION_MODES_PATH_FORMAT = "/hmsweb/automation/v3/modes?locationId={0}"  # {0} is _location_id
+LOCATION_AUTOMATION_PATH_FORMAT = "/hmsweb/automation/v3?locationId={0}&revisions=false"  # {0} is _location_id
 LOCATION_ACTIVEMODE_PATH_FORMAT = "/hmsweb/automation/v3/activeMode?locationId={0}"  # {0} is _location_id
 LOCATIONS_EMERGENCY_PATH = "/hmsweb/users/emergency/locations"
 

--- a/pyaarlo/location.py
+++ b/pyaarlo/location.py
@@ -47,7 +47,15 @@ class ArloLocation(ArloSuper):
         return self._load([MODE_ID_TO_NAME_KEY, mode_id], None)
 
     def _name_to_id(self, mode_name):
-        return self._load([MODE_NAME_TO_ID_KEY, mode_name], None)
+        # Try exact match first
+        result = self._load([MODE_NAME_TO_ID_KEY, mode_name], None)
+        if result is not None:
+            return result
+        # Try case-insensitive match
+        for key, value in self._load_matching([MODE_NAME_TO_ID_KEY, "*"]):
+            if key.split("/")[-1].lower() == mode_name.lower():
+                return value
+        return None
 
     def _custom_uuid_for_device(self, device_id, mode_name_or_uuid):
         """Resolve a custom mode name or UUID to a UUID for a given device_id.
@@ -80,8 +88,11 @@ class ArloLocation(ArloSuper):
                 if not isinstance(mode_data, dict):
                     continue
                 name = mode_data.get("name", "")
-                # Skip internal sentinels
+                # For modes with empty or sentinel names (e.g. migrated V2 modes like
+                # "armed", "disarmed", "schedule"), use the key itself as the name.
                 if name in ("", "__DEFAULT_DISARMED__"):
+                    name = uuid
+                if not name:
                     continue
                 self.debug(f"custom mode: {device_id} {uuid}<=CM=>{name}")
                 self._save([CUSTOM_MODE_UUID_KEY, device_id, name], uuid)
@@ -188,7 +199,7 @@ class ArloLocation(ArloSuper):
             return
 
         # Need to change?
-        if self.mode == mode_id:
+        if self.mode.lower() == mode_id.lower():
             self.debug("no mode change needed")
             return
 
@@ -198,19 +209,22 @@ class ArloLocation(ArloSuper):
 
         # Build the PUT body — standard modes vs V3 custom modes
         custom_uuid = None
-        # First try with _device_ids
+        # First try with _device_ids (exact match)
         for device_id in self._device_ids:
             uuid = self._custom_uuid_for_device(device_id, mode_id)
             if uuid is not None:
                 custom_uuid = (device_id, uuid)
                 break
-        # If not found, search all device_ids in the custom mode cache
+        # If not found, search all device_ids in the custom mode cache (case-insensitive)
         if custom_uuid is None:
-            for key, uuid in self._load_matching([CUSTOM_MODE_UUID_KEY, "*", mode_id]):
+            for key, uuid in self._load_matching([CUSTOM_MODE_UUID_KEY, "*", "*"]):
                 # key format: customModeUuid/<device_id>/<mode_name>
                 parts = key.split("/")
-                if len(parts) >= 2:
+                if len(parts) >= 2 and parts[-1].lower() == mode_id.lower():
                     device_id = parts[-2]
+                    # strip userId prefix if present (e.g. "userId_deviceId" -> "deviceId")
+                    if "_" in device_id:
+                        device_id = device_id.split("_", 1)[-1]
                     custom_uuid = (device_id, uuid)
                     break
 

--- a/pyaarlo/location.py
+++ b/pyaarlo/location.py
@@ -3,6 +3,7 @@ from .constant import (
     MODE_KEY,
     MODE_NAME_TO_ID_KEY,
     LOCATION_MODES_PATH_FORMAT,
+    LOCATION_AUTOMATION_PATH_FORMAT,
     LOCATION_ACTIVEMODE_PATH_FORMAT,
     MODE_REVISION_KEY
 )
@@ -16,6 +17,11 @@ DEFAULT_MODES = {
     "armAway": "Armed Away",
     "armHome": "Armed Home"
 }
+
+# Key used to store the device_id → custom_modes UUID map
+CUSTOM_MODE_UUID_KEY = "customModeUuid"
+# Sentinel stored as mode_id when the active mode is a V3 custom mode
+CUSTOM_MODE_SENTINEL = "custom"
 
 
 def location_name(name, user):
@@ -43,6 +49,61 @@ class ArloLocation(ArloSuper):
     def _name_to_id(self, mode_name):
         return self._load([MODE_NAME_TO_ID_KEY, mode_name], None)
 
+    def _custom_uuid_for_device(self, device_id, mode_name_or_uuid):
+        """Resolve a custom mode name or UUID to a UUID for a given device_id.
+
+        Returns the UUID string, or None if not found.
+        """
+        # Try name → uuid lookup first
+        uuid = self._load([CUSTOM_MODE_UUID_KEY, device_id, mode_name_or_uuid], None)
+        if uuid is not None:
+            return uuid
+        # Already a UUID? Check it exists in the map
+        for key, stored_uuid in self._load_matching([CUSTOM_MODE_UUID_KEY, device_id, "*"]):
+            if stored_uuid == mode_name_or_uuid:
+                return mode_name_or_uuid
+        return None
+
+    def _uuid_to_custom_name(self, device_id, uuid):
+        """Resolve a UUID to the custom mode name for a given device_id."""
+        for key, stored_uuid in self._load_matching([CUSTOM_MODE_UUID_KEY, device_id, "*"]):
+            if stored_uuid == uuid:
+                return key.split("/")[-1]
+        return uuid
+
+    def _parse_custom_modes(self, custom_modes_properties):
+        """Parse the customModes.properties.<deviceId> structure and store name→UUID map."""
+        for device_id, modes in custom_modes_properties.items():
+            if not isinstance(modes, dict):
+                continue
+            for uuid, mode_data in modes.items():
+                if not isinstance(mode_data, dict):
+                    continue
+                name = mode_data.get("name", "")
+                # Skip internal sentinels
+                if name in ("", "__DEFAULT_DISARMED__"):
+                    continue
+                self.debug(f"custom mode: {device_id} {uuid}<=CM=>{name}")
+                self._save([CUSTOM_MODE_UUID_KEY, device_id, name], uuid)
+
+    def _resolve_active_mode(self, properties):
+        """Resolve the active mode from a V3 activeMode response properties dict.
+
+        Returns a human-readable mode name or a plain mode_id string.
+        """
+        mode = properties.get("mode", None)
+        if mode != CUSTOM_MODE_SENTINEL:
+            # Standard mode: standby, armHome, armAway — return as-is
+            return mode
+        # Custom mode: resolve UUID → name for each device
+        custom = properties.get("custom", {})
+        names = []
+        for device_id, uuid in custom.items():
+            name = self._uuid_to_custom_name(device_id, uuid)
+            names.append(name)
+        # Return the first resolved name (single base station setup)
+        return names[0] if names else CUSTOM_MODE_SENTINEL
+
     def _extra_headers(self):
         return {
             "x-forwarded-user": self._arlo.be.user_id,
@@ -64,7 +125,8 @@ class ArloLocation(ArloSuper):
         # A (user requested?) mode change.
         if resource == AUTOMATION_ACTIVE_MODE:
             props = event.get("properties", {})
-            mode = props.get("properties", {}).get("mode", None)
+            raw_props = props.get("properties", {})
+            mode = self._resolve_active_mode(raw_props)
             if mode is not None:
                 self._save_and_do_callbacks(MODE_KEY, mode)
             mode_revision = props.get("revision", None)
@@ -130,14 +192,30 @@ class ArloLocation(ArloSuper):
             self.debug("no mode change needed")
             return
 
-        # Post change.
         self.debug(f"new-mode={mode_id}({id_or_name})")
         mode_revision = self._load(MODE_REVISION_KEY, 1)
         self.vdebug(f"old-revision={mode_revision}")
 
+        # Build the PUT body — standard modes vs V3 custom modes
+        custom_uuid = None
+        for device_id in self._device_ids:
+            uuid = self._custom_uuid_for_device(device_id, mode_id)
+            if uuid is not None:
+                custom_uuid = (device_id, uuid)
+                break
+
+        if custom_uuid is not None:
+            device_id, uuid = custom_uuid
+            params = {
+                "mode": CUSTOM_MODE_SENTINEL,
+                "custom": {device_id: uuid}
+            }
+        else:
+            params = {"mode": mode_id}
+
         data = self._arlo.be.put(
             LOCATION_ACTIVEMODE_PATH_FORMAT.format(self._id) + f"&revision={mode_revision}",
-            params={"mode": mode_id},
+            params=params,
             headers=self._extra_headers())
 
         mode_revision = data.get("revision")
@@ -155,19 +233,28 @@ class ArloLocation(ArloSuper):
         """Check and update the base's current mode."""
         data = self._arlo.be.get(LOCATION_ACTIVEMODE_PATH_FORMAT.format(self._id),
                                  headers=self._extra_headers())
-        mode_id = data.get("properties", {}).get('mode')
+        mode_id = self._resolve_active_mode(data.get("properties", {}))
         mode_revision = data.get("revision")
         self._save_and_do_callbacks(MODE_KEY, mode_id)
         self._save(MODE_REVISION_KEY, mode_revision)
 
     def update_modes(self, _initial=False):
         """Get and update the available modes for the base."""
-        modes = self._arlo.be.get(LOCATION_MODES_PATH_FORMAT.format(self._id),
-                                  headers=self._extra_headers())
-        if modes is not None:
-            self._parse_modes(modes.get("properties", {}))
-        else:
+        data = self._arlo.be.get(LOCATION_AUTOMATION_PATH_FORMAT.format(self._id),
+                                 headers=self._extra_headers())
+        if data is None:
             self._arlo.error("failed to read modes.")
+            return
+
+        # Parse standard modes (standby, armHome, armAway)
+        modes = data.get("modes", {}).get("properties", {})
+        if modes:
+            self._parse_modes(modes)
+
+        # Parse custom modes (V3: customModes.properties.<deviceId>.<uuid> = {name:...})
+        custom_modes = data.get("customModes", {}).get("properties", {})
+        if custom_modes:
+            self._parse_custom_modes(custom_modes)
 
     def stand_by(self):
         self.mode = "standby"

--- a/pyaarlo/location.py
+++ b/pyaarlo/location.py
@@ -198,11 +198,21 @@ class ArloLocation(ArloSuper):
 
         # Build the PUT body — standard modes vs V3 custom modes
         custom_uuid = None
+        # First try with _device_ids
         for device_id in self._device_ids:
             uuid = self._custom_uuid_for_device(device_id, mode_id)
             if uuid is not None:
                 custom_uuid = (device_id, uuid)
                 break
+        # If not found, search all device_ids in the custom mode cache
+        if custom_uuid is None:
+            for key, uuid in self._load_matching([CUSTOM_MODE_UUID_KEY, "*", mode_id]):
+                # key format: customModeUuid/<device_id>/<mode_name>
+                parts = key.split("/")
+                if len(parts) >= 2:
+                    device_id = parts[-2]
+                    custom_uuid = (device_id, uuid)
+                    break
 
         if custom_uuid is not None:
             device_id, uuid = custom_uuid
@@ -217,6 +227,10 @@ class ArloLocation(ArloSuper):
             LOCATION_ACTIVEMODE_PATH_FORMAT.format(self._id) + f"&revision={mode_revision}",
             params=params,
             headers=self._extra_headers())
+
+        if data is None:
+            self._arlo.error("failed to set mode.")
+            return
 
         mode_revision = data.get("revision")
         self.vdebug(f"new-revision={mode_revision}")
@@ -233,6 +247,9 @@ class ArloLocation(ArloSuper):
         """Check and update the base's current mode."""
         data = self._arlo.be.get(LOCATION_ACTIVEMODE_PATH_FORMAT.format(self._id),
                                  headers=self._extra_headers())
+        if data is None:
+            self._arlo.error("failed to read active mode.")
+            return
         mode_id = self._resolve_active_mode(data.get("properties", {}))
         mode_revision = data.get("revision")
         self._save_and_do_callbacks(MODE_KEY, mode_id)


### PR DESCRIPTION
## Problem

Arlo forced a migration to V3 API for some accounts. In V3:
- Custom modes (including modes migrated from V2) are managed at the
  **location** level, not the base station
- The base station no longer has its own mode — it delegates to the location
- Custom mode names and UUIDs come from `customModes.properties` in
  `/hmsweb/automation/v3`

This broke:
1. Custom mode discovery
2. Mode switching from Home Assistant alarm control panel
3. Alarm panel state display (active mode not reflected correctly)

## Changes

### `pyaarlo/location.py`
- Parse `customModes.properties` from `/hmsweb/automation/v3` response
- Store custom mode UUID→name mapping in cache (case-insensitive lookup)
- Implement `mode.setter` using `PUT /hmsweb/automation/v3/activeMode`
- Implement `update_mode()` using `GET /hmsweb/automation/v3/activeMode`
- Store migrated V2 modes using their key as fallback name when the API
  returns empty or sentinel names (`__DEFAULT_DISARMED__`)
- Guard against `None` API responses

### `pyaarlo/__init__.py`
- Call `location.update_modes()` in `_refresh_bases()` at startup

### `pyaarlo/base.py`
- In V3, delegate `mode.setter` to the associated location
- Handle `feedNotification` events to update `MODE_KEY` with the active
  mode name — required for hass-aarlo to correctly reflect the current mode

### `pyaarlo/constant.py`
- Add `LOCATION_AUTOMATION_PATH_FORMAT` and `LOCATION_ACTIVEMODE_PATH_FORMAT`

## hass-aarlo companion change (minor PR required)

A small change is needed in hass-aarlo's `alarm_control_panel.py`:

```python
# Before
lmode = mode.lower()
self._base.mode = lmode

# After
self._base.mode = mode  # preserve case for pyaarlo's case-insensitive lookup
```

## Testing

Tested on VMB5000 firmware 0.8.1.19 with custom modes and migrated V2 modes.
All modes switchable from HA alarm control panel with bidirectional sync.

## Note 
The only configuration change I had to make was in my integration. The mode names I was used to set up were in French (Activé, Desactivé ...) and they have been migrated in English (Armed, Schedule ...). All the custom names remained what I entered long time ago.

fixes https://github.com/twrecked/pyaarlo/issues/195
