### PR TITLE
Fix IMAP 2FA OTP extraction on Latin-1 / text-plain mail

### DIFF
--- a/pyaarlo/tfa.py
+++ b/pyaarlo/tfa.py
@@ -134,11 +134,20 @@ class Arlo2FAImap:
                         try:
                             if isinstance(msg[1], bytes):
                                 for part in email.message_from_bytes(msg[1]).walk():
-                                    if part.get_content_type() != "text/html":
+                                    if part.get_content_type() not in ("text/plain", "text/html"):
                                         continue
-                                    for line in part.get_payload(decode=True).splitlines():
+                                    payload = part.get_payload(decode=True)
+                                    if not payload:
+                                        continue
+                                    charset = part.get_content_charset() or "utf-8"
+                                    try:
+                                        body_text = payload.decode(charset, errors="replace")
+                                    except Exception as e:
+                                        self.debug(f"decode failed: {e}")
+                                        continue
+                                    for line in body_text.splitlines():
                                         # match code in email, this might need some work if the email changes
-                                        code = re.match(r"^\W+(\d{6})\W*$", line.decode())
+                                        code = re.match(r"^\W*(\d{6})\W*$", line.strip())
                                         if code is not None:
                                             self.debug(f"code={code.group(1)}")
                                             return code.group(1)


### PR DESCRIPTION
## Problem

`Arlo2FAImap.get` fails to extract the OTP from current Arlo 2FA verification emails when the message body is encoded as anything other than UTF-8 (commonly `iso-8859-1` when the mail traverses a mail host that re-encodes), or when the OTP is only present as a clean digit-only line in the `text/plain` alternative part.

Observed in the wild on Arlo's current `do_not_reply@arlo.com` 2FA mail forwarded through `outlook.com` → Gmail:

```
2fa-imap: new-msg=b'65116'
2fa-imap: trying next part 'utf-8' codec can't decode byte 0xa9 in position 0: invalid start byte
2fa-imap: trying next part index out of range
[...repeats until tfa_total_timeout, then login fails]
```

The `0xa9` byte is `©` (U+00A9) in the Latin-1-encoded footer of Arlo's mail. The body-parse loop crashes on the first non-ASCII byte, bails out via the `except` (logged as `trying next part`), and never reaches the line with the OTP.

## Root cause

Three issues in the inner loop at [`pyaarlo/tfa.py` Arlo2FAImap.get](https://github.com/twrecked/pyaarlo/blob/master/pyaarlo/tfa.py#L133-L146):

1. **Only `text/html` is examined.** In current Arlo mail the cleanest place to find the OTP is the `text/plain` alternative, which contains a bare line like `467266`. The `text/html` part embeds it as `467266 </h1>` — even with the encoding fixed, the existing regex wouldn't match that.
2. **`line.decode()` defaults to UTF-8** and ignores the MIME part's declared `Content-Type` charset. Latin-1 (and any other non-UTF-8) body fails immediately at the first multi-byte sequence.
3. **`re.match(r"^\W+(\d{6})\W*$", …)` requires at least one leading non-word character.** A bare digit-only line from `text/plain` doesn't match because it starts directly with a digit (a word char).

## Fix

In the same loop:

- Walk both `text/plain` and `text/html` parts.
- Decode each part's payload via `part.get_content_charset() or "utf-8"` with `errors="replace"`, wrapped in a try so a malformed part skips cleanly instead of breaking out of the loop.
- Relax the regex's leading anchor from `\W+` to `\W*` and `line.strip()` first, so a bare 6-digit line matches without requiring leading whitespace.

After the fix, on the same input message:

```
2fa-imap: new-msg=b'65116'
2fa-imap: code=391439
[login succeeds]
```

## Compatibility

Backward-compatible for the existing `text/html` / UTF-8 case:

- Lines that previously matched still match — `\W*` is a superset of `\W+`, and `strip()` doesn't affect ASCII OTP lines.
- UTF-8 remains the fallback when `get_content_charset()` returns `None`, so messages without an explicit charset declaration behave as before.

Tested manually against a forwarded Arlo verification email with `Content-Type: text/plain; charset=iso-8859-1` and an unforwarded ASCII/UTF-8 Arlo verification email — both extract the OTP correctly with the patched code.

## Note

This is a different bug from #188 (which is whitespace in the IMAP password causing an encode error during connection, before the body is ever fetched).