### PR TITLE
Add extra_device_states option to accept additional device states (fixes #199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,12 @@ the top and work down:
   value is minutes and a good starting point is 90.
 * `request_timeout`, the amount of time to allow for a http request to work. A
   good starting point is 120 seconds.
+* `extra_device_states`, a list of additional device `state` values to accept on
+  top of the built-in `provisioned`/`synced`. Use this if a working camera is
+  missing because the legacy device API reports it with another state (for
+  example `deactivated` after a remove/re-add in the new Arlo app). Accepts a
+  single string or a list, e.g. `extra_device_states=["deactivated"]`. Matching
+  is case-insensitive. Leave unset to keep the default behaviour.
 
 Alro will allow shared accounts to give cameras their own name. If you find
 cameras appearing with unexpected names (or not appearing at all), log into the

--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -214,11 +214,12 @@ class PyArlo(object):
             self._refresh_locations()
         self._refresh_devices()
 
+        valid_device_states = VALID_DEVICE_STATES + self._cfg.extra_device_states
         for device in self._devices:
             dname = device.get("deviceName")
             dtype = device.get("deviceType")
             device_state = device.get("state", "unknown").lower()
-            if device_state not in VALID_DEVICE_STATES:
+            if device_state not in valid_device_states:
                 self.info(f"skipping {dname}: state is {device_state}")
                 continue
 

--- a/pyaarlo/cfg.py
+++ b/pyaarlo/cfg.py
@@ -117,6 +117,17 @@ class ArloCfg(object):
         return self._kw.get("max_days", 365)
 
     @property
+    def extra_device_states(self):
+        # Additional device `state` values to treat as valid, on top of the
+        # built-in VALID_DEVICE_STATES. Lets users opt in to devices the legacy
+        # API reports with states like "deactivated" (see issue #199). Accepts a
+        # single string or a list; matching is case-insensitive.
+        states = self._kw.get("extra_device_states", [])
+        if isinstance(states, str):
+            states = [states]
+        return [str(s).lower() for s in states]
+
+    @property
     def db_motion_time(self):
         return self._kw.get("db_motion_time", 30)
 


### PR DESCRIPTION
## Problem

`PyArlo` skips any device whose `state` is not in the hard-coded list in `constant.py`:

```python
VALID_DEVICE_STATES = ["provisioned", "synced"]
```

Some genuinely live cameras are reported by Arlo's **legacy device API** (`hmsweb/users/devices`, the only one pyaarlo reads) with a different state — most commonly `deactivated` after a camera is removed and re-added in the new Arlo app. Those devices are otherwise identical to working cameras (same model, same `arloRF`/`connected` shape) but get silently dropped:

```
[pyaarlo] skipping <name>: state is deactivated
```

…and show as `unavailable` in Home Assistant. See #199 for the full write-up.

## Change

Adds an **opt-in** `extra_device_states` config option that is appended to the built-in list when enumerating devices:

```python
pyaarlo = PyArlo(username=..., password=..., extra_device_states=["deactivated"])
```

- Accepts a single string or a list; matching is case-insensitive.
- **Default behaviour is unchanged** — with the option unset, only `provisioned`/`synced` are accepted, so devices Arlo has genuinely retired are still filtered out for everyone who doesn't opt in.
- Documented in the README options list.

This keeps the safe default while giving affected users a supported way to recover their cameras instead of hand-patching `constant.py` after every release.

Fixes #199