### PR TITLE
feat: add Arlo Feed metadata helpers (feed_metadata / feed_items)

### DIFF
--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -15,6 +15,7 @@ from .constant import (
     BLANK_IMAGE,
     DEVICES_PATH,
     FAST_REFRESH_INTERVAL,
+    FEED_METADATA_PATH_FORMAT,
     MODEL_ESSENTIAL_SPOTLIGHT,
     MODEL_ESSENTIAL_XL_SPOTLIGHT,
     MODEL_ESSENTIAL_INDOOR,
@@ -53,6 +54,41 @@ from .util import time_to_arlotime
 _LOGGER = logging.getLogger("pyaarlo")
 
 __version__ = "0.8.0.21"
+
+
+class FeedMetadataError(Exception):
+    """Raised when an Arlo Feed metadata response cannot be used."""
+
+    def __init__(
+        self,
+        message,
+        http_status=None,
+        response_type=None,
+        response_keys=None,
+        meta_code=None,
+        meta_error=None,
+    ):
+        self.http_status = http_status
+        self.response_type = response_type
+        self.response_keys = response_keys
+        self.meta_code = meta_code
+        self.meta_error = meta_error
+
+        details = []
+        if http_status is not None:
+            details.append("http_status={}".format(http_status))
+        if response_type is not None:
+            details.append("response_type={}".format(response_type))
+        if response_keys is not None:
+            details.append("response_keys={}".format(",".join(response_keys)))
+        if meta_code is not None:
+            details.append("meta_code={}".format(meta_code))
+        if meta_error is not None:
+            details.append("meta_error={}".format(meta_error))
+
+        if details:
+            message = "{} ({})".format(message, ", ".join(details))
+        Exception.__init__(self, message)
 
 
 class PyArlo(object):
@@ -723,6 +759,168 @@ class PyArlo(object):
         if device is None:
             device = self.lookup_light_by_id(device_id)
         return device
+
+    def feed_metadata(
+        self,
+        owner_id,
+        location_id,
+        from_date,
+        limit=200,
+        group_by="events",
+        next_page=None,
+        asc=False,
+    ):
+        """Return one Arlo Feed metadata page for a location.
+
+        :param owner_id: Owner/user id for the Arlo location.
+        :type owner_id: str
+        :param location_id: Arlo location id.
+        :type location_id: str
+        :param from_date: Starting date in YYYYMMDD format.
+        :type from_date: str
+        :param limit: Maximum number of Feed metadata groups to request.
+        :type limit: int
+        :param group_by: Feed grouping requested from Arlo.
+        :type group_by: str
+        :param next_page: Cursor from a previous response's `nextPage`.
+        :type next_page: str
+        :param asc: If `True`, request oldest-first ordering.
+        :type asc: bool
+        :return: Unwrapped Feed metadata response for one page.
+        :rtype: dict
+        :raises FeedMetadataError: if Arlo returns a failed or unrecognized
+          Feed metadata response.
+
+        Event Caption data, when present, is preserved in the raw response under
+        the Feed item's `harlem` field.
+        """
+        params = {
+            "asc": asc,
+            "fromDate": from_date,
+            "limit": limit,
+            "groupBy": group_by,
+        }
+        if next_page is not None:
+            params["nextPage"] = next_page
+
+        http_status, response = self.be.post_with_status(
+            FEED_METADATA_PATH_FORMAT.format(owner_id, location_id),
+            params,
+            raw=True,
+        )
+
+        if http_status != 200:
+            raise FeedMetadataError(
+                "Arlo Feed metadata request failed",
+                http_status=http_status,
+            )
+
+        if not isinstance(response, dict):
+            raise FeedMetadataError(
+                "Arlo Feed metadata request returned no usable response",
+                http_status=http_status,
+                response_type=type(response).__name__,
+            )
+
+        response_keys = tuple(sorted(str(key) for key in response.keys()))
+        meta = response.get("meta")
+        meta_error = meta.get("error") if isinstance(meta, dict) else None
+        if not isinstance(meta_error, int):
+            meta_error = None
+        if isinstance(meta, dict) and "code" in meta and meta.get("code") != 200:
+            raise FeedMetadataError(
+                "Arlo Feed metadata request failed",
+                http_status=http_status,
+                response_type="dict",
+                response_keys=response_keys,
+                meta_code=meta.get("code"),
+                meta_error=meta_error,
+            )
+
+        data = response.get("data")
+        if not isinstance(data, dict):
+            meta_code = meta.get("code") if isinstance(meta, dict) else None
+            raise FeedMetadataError(
+                "Arlo Feed metadata response missing metadata data",
+                http_status=http_status,
+                response_type="dict",
+                response_keys=response_keys,
+                meta_code=meta_code,
+                meta_error=meta_error,
+            )
+
+        return data
+
+    def _feed_items_from_metadata(self, metadata):
+        """Return Feed item dictionaries from a Feed metadata response."""
+        if not isinstance(metadata, dict):
+            return []
+
+        items = []
+        group_by_events = metadata.get("groupByEvents", {})
+        if not isinstance(group_by_events, dict):
+            return items
+
+        for event_groups in group_by_events.values():
+            if not isinstance(event_groups, list):
+                continue
+            for event_group in event_groups:
+                if not isinstance(event_group, dict):
+                    continue
+                for device_events in event_group.values():
+                    if not isinstance(device_events, list):
+                        continue
+                    for item in device_events:
+                        if isinstance(item, dict):
+                            items.append(item)
+
+        return items
+
+    def feed_items(
+        self,
+        owner_id,
+        location_id,
+        from_date,
+        limit=200,
+        next_page=None,
+        asc=False,
+    ):
+        """Return Feed item dictionaries for one Feed metadata page.
+
+        This requests Feed metadata grouped by events, then flattens the
+        `groupByEvents` response into the raw Feed item dictionaries.
+
+        :param owner_id: Owner/user id for the Arlo location.
+        :type owner_id: str
+        :param location_id: Arlo location id.
+        :type location_id: str
+        :param from_date: Starting date in YYYYMMDD format.
+        :type from_date: str
+        :param limit: Maximum number of Feed metadata groups to request.
+        :type limit: int
+        :param next_page: Cursor from a previous response's `nextPage`.
+        :type next_page: str
+        :param asc: If `True`, request oldest-first ordering.
+        :type asc: bool
+        :return: Raw Feed item dictionaries for one page.
+        :rtype: list
+        :raises FeedMetadataError: if the Feed metadata request fails or
+          returns an unrecognized response.
+
+        Event Caption data, when present, is preserved under each item's
+        `harlem` field. This method does not update media library videos.
+        """
+        return self._feed_items_from_metadata(
+            self.feed_metadata(
+                owner_id,
+                location_id,
+                from_date,
+                limit=limit,
+                group_by="events",
+                next_page=next_page,
+                asc=asc,
+            )
+        )
 
     def inject_response(self, response):
         """Inject a test packet into the event stream.

--- a/pyaarlo/backend.py
+++ b/pyaarlo/backend.py
@@ -1324,6 +1324,18 @@ class ArloBackEnd(object):
                 self._request, path, "POST", params, headers, False, raw, timeout
             )
 
+    def post_with_status(self, path, params=None, headers=None, raw=False, timeout=None):
+        """Post and return ``(http_status, body)`` without event wait handling."""
+        return self._request_tuple(
+            path=path,
+            method="POST",
+            params=params,
+            headers=headers,
+            stream=False,
+            raw=raw,
+            timeout=timeout,
+        )
+
     def auth_post(self, path, params=None, headers=None, raw=False, timeout=None, cookies=None):
         return self._request_tuple(
             path, "POST", params, headers, False, raw, timeout, self._arlo.cfg.auth_host, authpost=True, cookies=cookies

--- a/pyaarlo/backend.py
+++ b/pyaarlo/backend.py
@@ -248,7 +248,7 @@ class ArloBackEnd(object):
             return 500, None
 
         try:
-            if "application/json" in r.headers["Content-Type"]:
+            if "application/json" in r.headers.get("Content-Type", ""):
                 body = r.json()
             else:
                 body = r.text
@@ -256,7 +256,7 @@ class ArloBackEnd(object):
         except Exception as e:
             self._arlo.warning("body-error={}".format(type(e).__name__))
             self._arlo.debug(f"request-text={r.text}")
-            return 500, None
+            return r.status_code if r.status_code != 200 else 500, None
 
         self.vdebug("request-end={}".format(r.status_code))
         if r.status_code != 200:
@@ -264,6 +264,9 @@ class ArloBackEnd(object):
 
         if raw:
             return 200, body
+
+        if not isinstance(body, dict):
+            return 500, None
 
         # New auth style and TFA helper
         if "meta" in body:

--- a/pyaarlo/constant.py
+++ b/pyaarlo/constant.py
@@ -9,6 +9,7 @@ DEVICES_PATH = "/hmsweb/v2/users/devices"
 DEFINITIONS_PATH = "/hmsweb/users/automation/definitions"
 AUTOMATION_PATH = "/hmsweb/users/devices/automation/active"
 LIBRARY_PATH = "/hmsweb/users/library"
+FEED_METADATA_PATH_FORMAT = "/hmsfeeds/users/{0}/{1}/metadata"  # {0} is owner_id, {1} is location_id
 LOGIN_PATH = "/hmsweb/login/v2"
 SESSION_PATH = "/hmsweb/users/session/v3"
 LOGOUT_PATH = "/hmsweb/logout"

--- a/tests/test_backend_request.py
+++ b/tests/test_backend_request.py
@@ -1,0 +1,104 @@
+import threading
+from unittest import TestCase
+
+from pyaarlo.backend import ArloBackEnd
+
+
+class FakeCfg(object):
+    host = "https://arlo.example"
+    request_timeout = 60
+
+
+class FakeArlo(object):
+    cfg = FakeCfg()
+
+    def __init__(self):
+        self.warnings = []
+        self.debugs = []
+
+    def warning(self, msg):
+        self.warnings.append(msg)
+
+    def debug(self, msg):
+        self.debugs.append(msg)
+
+    def vdebug(self, msg):
+        pass
+
+
+class FakeResponse(object):
+    def __init__(self, status_code, headers=None, text=""):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = text
+
+    def json(self):
+        raise ValueError("bad json")
+
+
+class FakeSession(object):
+    def __init__(self, response):
+        self.response = response
+
+    def post(self, url, json=None, headers=None, timeout=None, cookies=None):
+        return self.response
+
+
+class TestRequestTuple(TestCase):
+    def _backend_with_response(self, response):
+        backend = ArloBackEnd.__new__(ArloBackEnd)
+        backend._arlo = FakeArlo()
+        backend._req_lock = threading.Lock()
+        backend._session = FakeSession(response)
+        return backend
+
+    def test_body_parse_failure_preserves_http_error_status(self):
+        backend = self._backend_with_response(
+            FakeResponse(
+                429,
+                headers={"Content-Type": "application/json"},
+                text="not json",
+            )
+        )
+
+        code, body = backend._request_tuple("/test", method="POST")
+
+        self.assertEqual(code, 429)
+        self.assertIsNone(body)
+        self.assertEqual(backend._arlo.warnings, ["body-error=ValueError"])
+
+    def test_body_parse_failure_for_http_success_remains_request_failure(self):
+        backend = self._backend_with_response(
+            FakeResponse(
+                200,
+                headers={"Content-Type": "application/json"},
+                text="not json",
+            )
+        )
+
+        code, body = backend._request_tuple("/test", method="POST")
+
+        self.assertEqual(code, 500)
+        self.assertIsNone(body)
+
+    def test_missing_content_type_on_http_error_preserves_status(self):
+        backend = self._backend_with_response(FakeResponse(500, text="server error"))
+
+        code, body = backend._request_tuple("/test", method="POST", raw=True)
+
+        self.assertEqual(code, 500)
+        self.assertIsNone(body)
+
+    def test_http_success_text_body_is_not_treated_as_envelope(self):
+        backend = self._backend_with_response(
+            FakeResponse(
+                200,
+                headers={"Content-Type": "text/plain"},
+                text='{"meta": {"code": 200}, "data": {}}',
+            )
+        )
+
+        code, body = backend._request_tuple("/test", method="POST")
+
+        self.assertEqual(code, 500)
+        self.assertIsNone(body)

--- a/tests/test_feed_metadata.py
+++ b/tests/test_feed_metadata.py
@@ -1,0 +1,286 @@
+from inspect import signature
+from unittest import TestCase
+
+from pyaarlo import FeedMetadataError, PyArlo
+
+
+class FakeBackend(object):
+    def __init__(self, response=None, http_status=200):
+        self.response = response
+        self.http_status = http_status
+        self.posts = []
+
+    def post_with_status(self, path, params, raw=False):
+        self.posts.append((path, params, raw))
+        return self.http_status, self.response
+
+
+class TestFeedMetadata(TestCase):
+    def test_feed_metadata_posts_request_and_returns_data(self):
+        data = {
+            "groupByEvents": {
+                "event-key": [
+                    {
+                        "device-key": [
+                            {
+                                "feedId": "feed-id",
+                                "name": "video-id",
+                                "deviceId": "device-id",
+                                "harlem": [
+                                    {
+                                        "shortCaption": "Animal crosses yard",
+                                        "aiDigest": [
+                                            {
+                                                "sectionName": "Generic Description",
+                                                "content": "Animal crosses yard.",
+                                            }
+                                        ],
+                                        "highlight": False,
+                                        "modelName": "gemini",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            },
+            "nextPage": "next-page",
+        }
+        backend = FakeBackend({"meta": {"code": 200}, "data": data})
+        arlo = PyArlo.__new__(PyArlo)
+        arlo._be = backend
+
+        metadata = arlo.feed_metadata(
+            "owner-id",
+            "location-id",
+            "20260524",
+            limit=25,
+            group_by="type",
+            next_page="previous-page",
+            asc=True,
+        )
+
+        self.assertIs(metadata, data)
+        self.assertEqual(
+            backend.posts,
+            [
+                (
+                    "/hmsfeeds/users/owner-id/location-id/metadata",
+                    {
+                        "asc": True,
+                        "fromDate": "20260524",
+                        "limit": 25,
+                        "groupBy": "type",
+                        "nextPage": "previous-page",
+                    },
+                    True,
+                )
+            ],
+        )
+
+    def test_feed_metadata_uses_feed_defaults(self):
+        backend = FakeBackend({"meta": {"code": 200}, "data": {}})
+        arlo = PyArlo.__new__(PyArlo)
+        arlo._be = backend
+
+        metadata = arlo.feed_metadata("owner-id", "location-id", "20260524")
+
+        self.assertEqual(metadata, {})
+        self.assertEqual(
+            backend.posts[0],
+            (
+                "/hmsfeeds/users/owner-id/location-id/metadata",
+                {
+                    "asc": False,
+                    "fromDate": "20260524",
+                    "limit": 200,
+                    "groupBy": "events",
+                },
+                True,
+            ),
+        )
+
+    def test_feed_metadata_returns_data_when_meta_has_no_code(self):
+        data = {"groupByEvents": {}}
+        backend = FakeBackend({"meta": {}, "data": data})
+        arlo = PyArlo.__new__(PyArlo)
+        arlo._be = backend
+
+        metadata = arlo.feed_metadata("owner-id", "location-id", "20260524")
+
+        self.assertIs(metadata, data)
+
+    def test_feed_metadata_raises_for_http_failure(self):
+        backend = FakeBackend(None, http_status=429)
+        arlo = PyArlo.__new__(PyArlo)
+        arlo._be = backend
+
+        with self.assertRaises(FeedMetadataError) as ctx:
+            arlo.feed_metadata("owner-id", "location-id", "20260524")
+
+        self.assertEqual(ctx.exception.http_status, 429)
+        self.assertIsNone(ctx.exception.meta_code)
+        self.assertIsNone(ctx.exception.response_type)
+        self.assertIn("http_status=429", str(ctx.exception))
+
+    def test_feed_metadata_raises_for_meta_error(self):
+        backend = FakeBackend(
+            {
+                "meta": {
+                    "code": 400,
+                    "error": 9261,
+                    "message": "temporarily unavailable",
+                }
+            }
+        )
+        arlo = PyArlo.__new__(PyArlo)
+        arlo._be = backend
+
+        with self.assertRaises(FeedMetadataError) as ctx:
+            arlo.feed_metadata("owner-id", "location-id", "20260524")
+
+        self.assertEqual(ctx.exception.http_status, 200)
+        self.assertEqual(ctx.exception.response_type, "dict")
+        self.assertEqual(ctx.exception.response_keys, ("meta",))
+        self.assertEqual(ctx.exception.meta_code, 400)
+        self.assertEqual(ctx.exception.meta_error, 9261)
+        self.assertIn("response_keys=meta", str(ctx.exception))
+
+    def test_feed_metadata_raises_for_no_usable_response(self):
+        backend = FakeBackend("not-json")
+        arlo = PyArlo.__new__(PyArlo)
+        arlo._be = backend
+
+        with self.assertRaises(FeedMetadataError) as ctx:
+            arlo.feed_metadata("owner-id", "location-id", "20260524")
+
+        self.assertEqual(ctx.exception.http_status, 200)
+        self.assertEqual(ctx.exception.response_type, "str")
+        self.assertIsNone(ctx.exception.meta_code)
+
+    def test_feed_metadata_raises_for_missing_data(self):
+        backend = FakeBackend({"meta": {"code": 200}})
+        arlo = PyArlo.__new__(PyArlo)
+        arlo._be = backend
+
+        with self.assertRaises(FeedMetadataError) as ctx:
+            arlo.feed_metadata("owner-id", "location-id", "20260524")
+
+        self.assertEqual(ctx.exception.http_status, 200)
+        self.assertEqual(ctx.exception.response_type, "dict")
+        self.assertEqual(ctx.exception.response_keys, ("meta",))
+        self.assertEqual(ctx.exception.meta_code, 200)
+
+    def test_feed_metadata_raises_for_non_dict_data(self):
+        backend = FakeBackend({"meta": {"code": 200}, "data": []})
+        arlo = PyArlo.__new__(PyArlo)
+        arlo._be = backend
+
+        with self.assertRaises(FeedMetadataError) as ctx:
+            arlo.feed_metadata("owner-id", "location-id", "20260524")
+
+        self.assertEqual(ctx.exception.http_status, 200)
+        self.assertEqual(ctx.exception.response_type, "dict")
+        self.assertEqual(ctx.exception.response_keys, ("data", "meta"))
+        self.assertEqual(ctx.exception.meta_code, 200)
+
+    def test_feed_items_flattens_group_by_events(self):
+        harlem = [
+            {
+                "shortCaption": "Animal crosses yard",
+                "modelName": "gemini",
+            }
+        ]
+        first_item = {
+            "feedId": "feed-id-1",
+            "name": "video-id-1",
+            "deviceId": "device-id-1",
+            "harlem": harlem,
+        }
+        second_item = {
+            "feedId": "feed-id-2",
+            "name": "video-id-2",
+            "deviceId": "device-id-2",
+        }
+        third_item = {
+            "feedId": "feed-id-3",
+            "name": "video-id-3",
+            "deviceId": "device-id-3",
+        }
+        data = {
+            "groupByEvents": {
+                "event-key-1": [
+                    {
+                        "device-key-1": [
+                            first_item,
+                            second_item,
+                        ],
+                        "device-key-2": [
+                            third_item,
+                        ],
+                    }
+                ],
+            },
+            "nextPage": "next-page",
+        }
+        backend = FakeBackend({"meta": {"code": 200}, "data": data})
+        arlo = PyArlo.__new__(PyArlo)
+        arlo._be = backend
+
+        items = arlo.feed_items(
+            "owner-id",
+            "location-id",
+            "20260524",
+            limit=25,
+            next_page="previous-page",
+        )
+
+        self.assertEqual(items, [first_item, second_item, third_item])
+        self.assertIs(items[0], first_item)
+        self.assertIs(items[1], second_item)
+        self.assertIs(items[2], third_item)
+        self.assertIs(items[0]["harlem"], harlem)
+        self.assertEqual(
+            backend.posts,
+            [
+                (
+                    "/hmsfeeds/users/owner-id/location-id/metadata",
+                    {
+                        "asc": False,
+                        "fromDate": "20260524",
+                        "limit": 25,
+                        "groupBy": "events",
+                        "nextPage": "previous-page",
+                    },
+                    True,
+                )
+            ],
+        )
+
+    def test_feed_items_always_requests_event_grouping(self):
+        self.assertNotIn("group_by", signature(PyArlo.feed_items).parameters)
+
+        backend = FakeBackend({"meta": {"code": 200}, "data": {}})
+        arlo = PyArlo.__new__(PyArlo)
+        arlo._be = backend
+
+        arlo.feed_items("owner-id", "location-id", "20260524")
+
+        self.assertEqual(backend.posts[0][1]["groupBy"], "events")
+
+    def test_feed_items_propagates_metadata_errors(self):
+        backend = FakeBackend(None, http_status=500)
+        arlo = PyArlo.__new__(PyArlo)
+        arlo._be = backend
+
+        with self.assertRaises(FeedMetadataError) as ctx:
+            arlo.feed_items("owner-id", "location-id", "20260524")
+
+        self.assertEqual(ctx.exception.http_status, 500)
+
+    def test_feed_items_returns_empty_list_for_unexpected_metadata(self):
+        arlo = PyArlo.__new__(PyArlo)
+
+        self.assertEqual(arlo._feed_items_from_metadata(None), [])
+        self.assertEqual(arlo._feed_items_from_metadata({}), [])
+        self.assertEqual(arlo._feed_items_from_metadata({"groupByEvents": []}), [])


### PR DESCRIPTION
# Add Arlo Feed metadata helpers (`feed_metadata` / `feed_items`)

## Why

Arlo exposes a **Feed metadata** endpoint
(`/hmsfeeds/users/{owner_id}/{location_id}/metadata`) that carries per-event
metadata — including Arlo's AI **event captions** — for a location. pyaarlo has
no way to reach it today, so anything that wants those captions has to hand-roll
the request and response handling. This adds first-class, read-only access.

## What this adds

Two new public methods on `PyArlo`, plus a typed error:

- **`feed_metadata(owner_id, location_id, from_date, limit=200, group_by="events", next_page=None, asc=False)`**
  — returns one validated metadata page (the unwrapped `data` dict). Raises
  `FeedMetadataError` (with `http_status` / `meta_code` / … diagnostics) on any
  malformed response.
- **`feed_items(owner_id, location_id, from_date, ...)`** — convenience wrapper
  that requests `groupBy="events"` and flattens one page into a list of raw item
  dicts. Event captions, when present, ride under each item's `harlem` field.
- **`FeedMetadataError`** — carries structured diagnostic fields (field
  names/codes only, never tokens or payload values) plus a readable message.

```python
page  = arlo.feed_metadata(owner_id, location_id, from_date="20260601")
nxt   = page.get("nextPage")        # pass back as next_page= to fetch the next page
items = arlo.feed_items(owner_id, location_id, from_date="20260601")
for item in items:
    caption = item.get("harlem")    # AI event-caption payload, when present
```

These are deliberately minimal: **single-page reads, no automatic pagination,
no media-library mutation.** Pagination is left to the caller via the
`nextPage` cursor in the returned dict.

## Changes

- **`pyaarlo/constant.py`** — add `FEED_METADATA_PATH_FORMAT`.
- **`pyaarlo/__init__.py`** — add `feed_metadata()`, `feed_items()`,
  `_feed_items_from_metadata()`, and the `FeedMetadataError` class.
- **`pyaarlo/backend.py`** — add `post_with_status()` (returns
  `(http_status, body)` so the caller can see the HTTP status); harden
  `_request_tuple` response parsing (3 small fixes, see below).
- **`tests/`** — add `test_feed_metadata.py` and `test_backend_request.py`.

## Shared request-path changes (please read)

To support the feed caller (which needs the HTTP status) and harden response
parsing, this PR makes **3 small edits to the shared `_request_tuple`**. The
dict-envelope path every existing caller relies on is **unchanged** — these only
affect previously-broken or error paths, and each is covered by
`tests/test_backend_request.py`:

| Change | Before | After |
|---|---|---|
| `headers.get("Content-Type", "")` | missing header → `KeyError` → `(500, None)` | missing header → `body = r.text` |
| status preserved on body-parse error | always `(500, None)` (real code masked) | keeps real non-200 status; still 500 if status was 200 |
| `if not isinstance(body, dict)` guard | a 200 text body containing the substring `meta`/`success` reached `body["meta"]` on a `str` → **uncaught `TypeError`** | clean `(500, None)` |

The non-dict guard fixes a **genuine latent crash**, independent of this
feature. `post_with_status()` returns `(http_status, body)` (bypassing the
event-wait machinery of `post()`); only the feed code calls it.

One behaviour nuance worth flagging: the auth retry loop is for transient
Cloudflare / rate-limit failures (per its `# Handle 1015 error` comment), and a
`401` already breaks out of it. With this change, a `401` whose body fails to
parse *also* breaks on the first attempt instead of being treated as `500` and
re-tried — the login outcome is unchanged (`CAN_RETRY` either way); it just
avoids a few redundant retries on a definitive `401`.

*The hardening is in its own commit; happy to split it into a separate PR, or to
squash the two commits into one, whichever you prefer to review — the feature
does not depend on the hardening.*

## Testing

`python -m unittest discover -s tests` → **27 passed** (11 existing + 16 new).
The new tests cover all four `feed_metadata` validation gates, the `feed_items`
flatten + `groupBy="events"` contract, and the three backend hardening changes.
No new dependencies; compatible with the declared `python_requires>=3.7`.

## Notes

- I left the `changelog` and version untouched for you to handle on merge, per
  the repo's convention.
