### PR TITLE
feat: add SIP/WebRTC signaling support for live streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,38 @@ The options are:
 - `linux`; returns a `MPEG-DASH` stream
 
 
+<a name="sip-webrtc"></a>
+## SIP/WebRTC Streaming
+
+Arlo's official apps - including my.arlo.com in a browser - negotiate live
+video over WebRTC, signaled through SIP messages sent over a WebSocket. This
+is a separate engine from the `startStream` relay described above, and the
+two are mutually exclusive on the camera at any given moment (Arlo's own
+error message when this happens is *"SIP Streaming in progress, RTSP
+Streaming is not allowed"*).
+
+Not every camera speaks it - check `camera.supports_sip_streaming` first.
+pyaarlo's SIP client is signaling-only: it takes a WebRTC offer SDP you
+built yourself and returns Arlo's answer SDP, but it never creates a peer
+connection or touches a media packet. You still need your own WebRTC stack
+(a browser, `aiortc`, `go2rtc`, ...) to build the offer and play the answer.
+
+```python
+info = cam.get_sip_info()          # REST only, returns ICE servers
+offer_sdp = my_webrtc_stack.create_offer(info["ice_servers"])
+answer_sdp = cam.start_sip_stream(offer_sdp)
+my_webrtc_stack.set_answer(answer_sdp)
+...
+cam.stop_sip_stream()
+```
+
+See `examples/sip-stream` for a runnable version of the signaling handshake,
+and `pyaarlo camera <name> sip-info` on the CLI for a quick check of whether
+a given camera responds to SIP at all.
+
+Related `kwargs`: `sip_timeout`, `sip_keepalive`, `sip_user_agent`, `sip_ws_port`.
+
+
 <a name="saving-media"></a>
 ## Saving Media
 

--- a/examples/sip-stream
+++ b/examples/sip-stream
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+#
+# Negotiates a SIP/WebRTC call against one camera and prints Arlo's answer
+# SDP. This is a signaling-only example: pyaarlo's SIP client never touches
+# media, so you still need your own WebRTC stack (a browser, aiortc, go2rtc,
+# ...) to build the offer this script sends and to play the answer it gets
+# back. See `pyaarlo/sip.py` for why that split exists.
+#
+# Usage:
+#   ARLO_USERNAME=... ARLO_PASSWORD=... ./sip-stream <camera-name> [offer.sdp]
+#
+# With no offer file, it just prints whether the camera supports SIP
+# streaming and, if so, the ICE servers Arlo published for it - useful on
+# its own to check a given model/firmware before writing any WebRTC code.
+
+import logging
+import os
+import sys
+
+# for examples add pyaarlo install path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+import pyaarlo
+
+USERNAME = os.environ.get('ARLO_USERNAME', 'test.login@gmail.com')
+PASSWORD = os.environ.get('ARLO_PASSWORD', 'test-password')
+
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+_LOGGER = logging.getLogger('pyaarlo')
+
+if len(sys.argv) < 2:
+    print("usage: {} <camera-name> [offer.sdp]".format(sys.argv[0]))
+    sys.exit(1)
+camera_name = sys.argv[1]
+offer_file = sys.argv[2] if len(sys.argv) > 2 else None
+
+arlo = pyaarlo.PyArlo(username=USERNAME, password=PASSWORD,
+                      tfa_type='EMAIL', tfa_source='console',
+                      save_session=True, save_state=False, storage_dir='aarlo')
+if not arlo.is_connected:
+    print("failed to login({})".format(arlo.last_error))
+    sys.exit(1)
+
+camera = None
+for c in arlo.cameras:
+    if c.name == camera_name:
+        camera = c
+        break
+if camera is None:
+    print("camera not found: {}".format(camera_name))
+    sys.exit(1)
+
+print("model={} interface-version={}".format(camera.model_id, camera.interface_version))
+print("supports-sip-streaming={}".format(camera.supports_sip_streaming))
+if not camera.supports_sip_streaming:
+    print("this camera does not report SIP support - stopping here")
+    sys.exit(0)
+
+info = camera.get_sip_info()
+print("ice-servers={}".format(info["ice_servers"]))
+
+if offer_file is None:
+    print("no offer file given - stopping after signaling handshake check")
+    camera.stop_sip_stream()
+    sys.exit(0)
+
+with open(offer_file, "r") as f:
+    offer_sdp = f.read()
+
+print("negotiating call...")
+answer_sdp = camera.start_sip_stream(offer_sdp)
+print("answer-sdp:")
+print(answer_sdp)
+
+camera.stop_sip_stream()

--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -141,6 +141,12 @@ class PyArlo(object):
     * **ecdh_curve** - Sets initial ecdhCurve for Cloudscraper. Available options are `prime256v1`
       and `secp384r1`. Backend will try all options if login fails.
     * **send_source** - Add a `Source` item to the authentication header, default is False.
+    * **sip_timeout** - Time, in seconds, to wait for a response to a single SIP transaction when using
+      `get_sip_info`/`start_sip_stream`. Default 5 seconds.
+    * **sip_keepalive** - Time, in seconds, between SIP keepAlive messages on an established SIP/WebRTC call.
+      Default 30 seconds.
+    * **sip_user_agent** - The `User-Agent` SIP header sent in SIP messages. Default `SIP.js/0.21.1`.
+    * **sip_ws_port** - Port used for the `wss://` SIP signaling connection. Default 7443.
 
     **Attributes**
 

--- a/pyaarlo/camera.py
+++ b/pyaarlo/camera.py
@@ -4,6 +4,7 @@ import threading
 import time
 import zlib
 
+from .capabilities import supports_sip_push_to_talk, supports_sip_streaming
 from .constant import (
     ACTIVITY_STATE_KEY,
     AIR_QUALITY_KEY,
@@ -74,6 +75,8 @@ from .constant import (
     RECORD_STOP_PATH,
     RECORDING_STOPPED_KEY,
     SIGNAL_STR_KEY,
+    SIP_PUSH_TO_TALK_KEY,
+    SIP_STREAMING_KEY,
     SIREN_STATE_KEY,
     SNAPSHOT_KEY,
     SPOTLIGHT_BRIGHTNESS_KEY,
@@ -84,6 +87,7 @@ from .constant import (
     TEMPERATURE_KEY,
 )
 from .device import ArloChildDevice
+from .sip import ArloSip, ArloSipError
 from .util import http_get, http_get_img, the_epoch
 
 
@@ -99,6 +103,8 @@ class ArloCamera(ArloChildDevice):
         self._event = threading.Event()
         self._snapshot_time = the_epoch()
         self._stream_url = None
+        # SIP/WebRTC signaling session, if one has been opened via get_sip_info()
+        self._sip = None
         # what user has requested locally
         self._user_requests = set()
         # what is keeping the stream open for us
@@ -913,8 +919,46 @@ class ArloCamera(ArloChildDevice):
         """Returns `True` if camera is streaming a video, `False` otherwise.
 
         Stream has to be started locally.
+
+        Covers both the RTSPS path (confirmed by the base station's
+        `userStreamActive` event) and the SIP/WebRTC path (confirmed
+        synchronously by Arlo's `200 OK` answer - see `start_sip_stream`).
         """
-        return self.has_user_request("streaming") or self.has_remote_user("streaming")
+        return (
+            self.has_user_request("streaming")
+            or self.has_remote_user("streaming")
+            or self.has_user_request("sip")
+            or self.has_remote_user("sip")
+        )
+
+    @property
+    def supports_sip_streaming(self):
+        """Returns `True` if this camera supports live SIP/WebRTC streaming.
+
+        See `has_capability(SIP_STREAMING_KEY)`.
+        """
+        return self.has_capability(SIP_STREAMING_KEY)
+
+    @property
+    def supports_sip_push_to_talk(self):
+        """Returns `True` if this camera signals push-to-talk over SIP.
+
+        See `has_capability(SIP_PUSH_TO_TALK_KEY)`.
+        """
+        return self.has_capability(SIP_PUSH_TO_TALK_KEY)
+
+    @property
+    def stream_protocols(self):
+        """Returns the set of streaming protocols this camera is known to support.
+
+        RTSPS (via `startStream`) is always included since it's the
+        universal fallback. `"sip"` is added when the capability document -
+        or, failing that, the fallback model list - says so.
+        """
+        protocols = {"rtsps"}
+        if self.supports_sip_streaming:
+            protocols.add("sip")
+        return protocols
 
     def has_user_request(self, activity):
         return activity in self._user_requests
@@ -1008,6 +1052,77 @@ class ArloCamera(ArloChildDevice):
 
     def stop_recording_stream(self):
         self._stop_stream("recording")
+
+    def get_sip_info(self):
+        """Opens SIP/WebRTC signaling for this camera and returns its ICE servers.
+
+        This is the protocol Arlo's own apps - including my.arlo.com in a
+        browser - actually use for live video: SIP-over-WebSocket carries
+        the offer/answer exchange, while a `RTCPeerConnection` you build
+        yourself carries the media. It exists alongside `start_stream()`'s
+        RTSPS relay, not instead of it - the two are separate engines and
+        mutually exclusive on the camera at any given moment, and
+        `supports_sip_streaming` tells you whether this camera has one at
+        all.
+
+        Build your WebRTC offer against the returned ICE servers, then pass
+        it to `start_sip_stream()`. This call is REST-only - it deliberately
+        does *not* open the signaling websocket, since whoever is building
+        the offer may take seconds to gather its ICE candidates and there's
+        no point holding a socket open through that. Safe to call again
+        while a session is already open.
+
+        :return: `{"ice_servers": [...]}`, shaped for an `RTCConfiguration`.
+        """
+        if self._sip is None:
+            self._sip = ArloSip(
+                self._arlo,
+                self,
+                timeout=self._arlo.cfg.sip_timeout,
+                keepalive_interval=self._arlo.cfg.sip_keepalive,
+                sip_user_agent=self._arlo.cfg.sip_user_agent,
+                ws_port=self._arlo.cfg.sip_ws_port,
+            )
+        self._sip.fetch_info()
+        return {"ice_servers": self._sip.ice_servers}
+
+    def start_sip_stream(self, offer_sdp):
+        """Negotiates a SIP/WebRTC call and returns Arlo's answer SDP.
+
+        Call `get_sip_info()` first - it opens the signaling connection and
+        hands you the ICE servers your offer needs to be built against.
+        This method only negotiates the call: pyaarlo never creates a peer
+        connection or touches a media packet on this path, so playing the
+        stream is entirely up to whatever built `offer_sdp`.
+
+        :param offer_sdp: A complete WebRTC offer SDP from your own peer connection.
+        :return: Arlo's answer SDP, repaired and ready to hand back to that peer connection.
+        """
+        if self._sip is None:
+            raise ArloSipError("call get_sip_info() first")
+
+        self._sip.ensure_connected()
+        answer_sdp = self._sip.start(offer_sdp)
+
+        with self._lock:
+            self._local_users.add("sip")
+            self._user_requests.add("sip")
+            self._dump_activities("_start_sip_stream")
+            self._lock.notify_all()
+
+        return answer_sdp
+
+    def stop_sip_stream(self):
+        """Ends the SIP/WebRTC call opened by `start_sip_stream()`, if any."""
+        if self._sip is not None:
+            self._sip.close()
+            self._sip = None
+
+        with self._lock:
+            self._local_users.discard("sip")
+            self._user_requests.discard("sip")
+            self._dump_activities("_stop_sip_stream")
+            self._lock.notify_all()
 
     def wait_for_user_stream(self, timeout=15):
         self.debug("waiting for stream")
@@ -1404,6 +1519,10 @@ class ArloCamera(ArloChildDevice):
         )
 
     def has_capability(self, cap):
+        if cap in (SIP_STREAMING_KEY,):
+            return supports_sip_streaming(self._arlo, self.model_id, self.interface_version)
+        if cap in (SIP_PUSH_TO_TALK_KEY,):
+            return supports_sip_push_to_talk(self._arlo, self.model_id, self.interface_version)
         if cap in (BATTERY_KEY,):
             if self.model_id.startswith((
                     MODEL_ESSENTIAL_INDOOR,

--- a/pyaarlo/capabilities.py
+++ b/pyaarlo/capabilities.py
@@ -1,0 +1,128 @@
+"""Capability detection for Arlo devices.
+
+Arlo publishes a per-model, per-interface-version document declaring which
+streaming and talk protocols a device actually supports:
+
+    GET https://myapi.arlo.com/resources/capabilities/<model>/<model>_<interfaceVersion>.json
+
+This document is the source of truth. The hardcoded model-prefix list below
+is a fallback only, used when the document can't be fetched - it is
+transcribed from a third-party project and is known to be incomplete (it
+does not, for example, include every hub-less Pro-series camera).
+
+A lookup failure here must never block RTSPS streaming, so every function in
+this module fails soft: no exceptions escape, and "unknown" always resolves
+to `{}` / `False` rather than raising.
+"""
+
+import time
+
+from .constant import (
+    CAPABILITIES_PATH_FORMAT,
+    MODEL_ESSENTIAL_INDOOR_GEN2_2K,
+    MODEL_ESSENTIAL_INDOOR_GEN2_HD,
+    MODEL_ESSENTIAL_OUTDOOR_GEN2_2K,
+    MODEL_ESSENTIAL_OUTDOOR_GEN2_HD,
+    MODEL_ESSENTIAL_VIDEO_DOORBELL,
+    MODEL_ESSENTIAL_XL_OUTDOOR_GEN2_2K,
+    MODEL_ESSENTIAL_XL_OUTDOOR_GEN2_HD,
+    MODEL_WIRED_VIDEO_DOORBELL,
+    MODEL_WIRED_VIDEO_DOORBELL_GEN2_2K,
+    MODEL_WIRED_VIDEO_DOORBELL_GEN2_HD,
+)
+
+CACHE_TTL = 24 * 60 * 60  # seconds
+
+FALLBACK_SIP_STREAMING_MODELS = (
+    MODEL_WIRED_VIDEO_DOORBELL,
+    MODEL_ESSENTIAL_VIDEO_DOORBELL,
+    MODEL_WIRED_VIDEO_DOORBELL_GEN2_HD,
+    MODEL_WIRED_VIDEO_DOORBELL_GEN2_2K,
+    MODEL_ESSENTIAL_OUTDOOR_GEN2_HD,
+    MODEL_ESSENTIAL_XL_OUTDOOR_GEN2_HD,
+    MODEL_ESSENTIAL_INDOOR_GEN2_HD,
+    MODEL_ESSENTIAL_OUTDOOR_GEN2_2K,
+    MODEL_ESSENTIAL_XL_OUTDOOR_GEN2_2K,
+    MODEL_ESSENTIAL_INDOOR_GEN2_2K,
+)
+
+# Tier 1 of the cache: process-local, keyed by "<model>_<interfaceVersion>".
+# Tier 2 is ArloStorage, so the document survives a restart (see arlo.st).
+_memory_cache = {}
+
+
+def _cache_key(model_id, interface_version):
+    return f"{model_id.lower()}_{interface_version}"
+
+
+def _storage_key(cache_key):
+    return ["ArloCapabilities", cache_key]
+
+
+def _fetch(arlo, model_id, interface_version):
+    path = CAPABILITIES_PATH_FORMAT.format(model_id.lower(), interface_version)
+    response = arlo.be.get(path, raw=True)
+    if not isinstance(response, dict):
+        arlo.debug(f"capabilities: no document for {model_id}/{interface_version}")
+        return {}
+    return response
+
+
+def get_capabilities(arlo, model_id, interface_version):
+    """Return the Arlo-published capability document for a model/interface-version pair.
+
+    Cached in memory and in `arlo.st` for `CACHE_TTL` seconds. Always
+    returns a dict, `{}` on any failure, so callers can chain `.get()`
+    lookups without special-casing errors.
+    """
+    if not model_id or not interface_version:
+        return {}
+
+    cache_key = _cache_key(model_id, interface_version)
+    now = time.time()
+
+    cached = _memory_cache.get(cache_key)
+    if cached is not None and cached[0] > now:
+        return cached[1]
+
+    stored = arlo.st.get(_storage_key(cache_key))
+    if stored is not None and stored.get("expires", 0) > now:
+        _memory_cache[cache_key] = (stored["expires"], stored["data"])
+        return stored["data"]
+
+    data = _fetch(arlo, model_id, interface_version)
+    expires = now + CACHE_TTL
+    _memory_cache[cache_key] = (expires, data)
+    arlo.st.set(_storage_key(cache_key), {"expires": expires, "data": data})
+    return data
+
+
+def supports_sip_streaming(arlo, model_id, interface_version):
+    """Returns `True` if the device supports live SIP/WebRTC streaming.
+
+    Trusts the capability document fully when it's available - including
+    when it explicitly says `False`. Only falls back to the (incomplete)
+    hardcoded model list when the document itself couldn't be obtained.
+    """
+    capabilities = get_capabilities(arlo, model_id, interface_version).get("Capabilities")
+    if capabilities is not None:
+        return bool(capabilities.get("Streaming", {}).get("SIPStreaming", False))
+    return model_id is not None and model_id.upper().startswith(
+        tuple(model.upper() for model in FALLBACK_SIP_STREAMING_MODELS)
+    )
+
+
+def supports_sip_push_to_talk(arlo, model_id, interface_version):
+    """Returns `True` if the device signals push-to-talk over SIP (vs. the notify/MQTT path)."""
+    capabilities = get_capabilities(arlo, model_id, interface_version).get("Capabilities")
+    if capabilities is None:
+        return False
+    return "sip" in capabilities.get("PushToTalk", {}).get("signal", [])
+
+
+def has_full_duplex_push_to_talk(arlo, model_id, interface_version):
+    """Returns `True` if the device supports simultaneous talk/listen push-to-talk."""
+    capabilities = get_capabilities(arlo, model_id, interface_version).get("Capabilities")
+    if capabilities is None:
+        return False
+    return bool(capabilities.get("PushToTalk", {}).get("fullDuplex", False))

--- a/pyaarlo/cfg.py
+++ b/pyaarlo/cfg.py
@@ -318,6 +318,26 @@ class ArloCfg(object):
         return self._kw.get("stream_snapshot_stop", 10)
 
     @property
+    def sip_timeout(self):
+        """Seconds to wait for a response to a single SIP transaction."""
+        return self._kw.get("sip_timeout", 5)
+
+    @property
+    def sip_keepalive(self):
+        """Seconds between SIP keepAlive MESSAGEs on an established call."""
+        return self._kw.get("sip_keepalive", 30)
+
+    @property
+    def sip_user_agent(self):
+        """The `User-Agent` SIP header sent in SIP messages (not the WebSocket handshake)."""
+        return self._kw.get("sip_user_agent", "SIP.js/0.21.1")
+
+    @property
+    def sip_ws_port(self):
+        """Port used for the `wss://` SIP signaling connection."""
+        return self._kw.get("sip_ws_port", 7443)
+
+    @property
     def save_media_to(self):
         return self._kw.get("save_media_to", "")
 

--- a/pyaarlo/constant.py
+++ b/pyaarlo/constant.py
@@ -22,6 +22,9 @@ RESTART_PATH = "/hmsweb/users/devices/restart"
 STREAM_SNAPSHOT_PATH = "/hmsweb/users/devices/takeSnapshot"
 STREAM_START_PATH = "/hmsweb/users/devices/startStream"
 IDLE_SNAPSHOT_PATH = "/hmsweb/users/devices/fullFrameSnapshot"
+SIP_INFO_PATH = "/hmsweb/users/devices/sipInfo"
+SIP_INFO_V2_PATH = "/hmsweb/users/devices/sipInfo/v2"
+CAPABILITIES_PATH_FORMAT = "/resources/capabilities/{0}/{0}_{1}.json"  # {0} is lowercased modelId, {1} is interfaceVersion
 CREATE_DEVICE_CERTS_PATH = "/hmsweb/users/devices/v2/security/cert/create"
 RATLS_TOKEN_GENERATE_PATH = "/hmsweb/users/device/ratls/token"
 RATLS_CONNECTIVITY_PATH = '/hmsls/connectivity'
@@ -249,6 +252,8 @@ TOTAL_CAMERAS_KEY = "totalCameras"
 TOTAL_LIGHTS_KEY = "totalLights"
 SILENT_MODE_CALL_KEY = "call"
 SILENT_MODE_ACTIVE_KEY = "active"
+SIP_STREAMING_KEY = "sipStreaming"
+SIP_PUSH_TO_TALK_KEY = "sipPushToTalk"
 
 # Media player
 MEDIA_PLAYER_RESOURCE_ID = "audioPlayback/player"

--- a/pyaarlo/device.py
+++ b/pyaarlo/device.py
@@ -5,6 +5,7 @@ from unidecode import unidecode
 if TYPE_CHECKING:
     from . import PyArlo
 
+from .capabilities import get_capabilities
 from .constant import (
     BATTERY_KEY,
     BATTERY_TECH_KEY,
@@ -94,6 +95,26 @@ class ArloDevice(ArloSuper):
     def hw_version(self):
         """Returns the hardware version."""
         return self._attrs.get("properties", {}).get("hwVersion", None)
+
+    @property
+    def interface_version(self):
+        """Returns the device's Arlo interface version.
+
+        Used, alongside `model_id`, to look up the device's published
+        capability document. See `capabilities`.
+        """
+        return self.attribute("interfaceVersion")
+
+    @property
+    def capabilities(self):
+        """Returns the device's Arlo-published capability document.
+
+        Declares which streaming/talk protocols the device actually
+        supports. Cached; see `pyaarlo.capabilities`. Returns `{}` if the
+        model or interface version is unknown, or the document couldn't be
+        fetched - this never blocks other functionality.
+        """
+        return get_capabilities(self._arlo, self.model_id, self.interface_version)
 
     @property
     def timezone(self):

--- a/pyaarlo/main.py
+++ b/pyaarlo/main.py
@@ -328,6 +328,19 @@ def list(item):
 
 
 @cli.command()
+def capabilities():
+    ar = login()
+    _print_start()
+    for c in ar.cameras:
+        _print(" {}".format(c.name))
+        _print("  model-id:{}".format(c.model_id))
+        _print("  interface-version:{}".format(c.interface_version))
+        _print("  stream-protocols:{}".format(",".join(sorted(c.stream_protocols))))
+        _print("  sip-push-to-talk:{}".format(c.supports_sip_push_to_talk))
+    _print_end()
+
+
+@cli.command()
 def encrypt():
     in_text = sys.stdin.read()
     enc_text = encrypt_to_string(in_text).rstrip()
@@ -366,8 +379,13 @@ def anonymize():
               help='camera device id')
 @click.option('-f', '--start-ffmpeg/--no-start-ffmpeg', required=False, default=False,
               help='start ffmpeg for stream')
-@click.argument('action', type=click.Choice(['start-stream', 'stop-stream', 'last-thumbnail'], case_sensitive=False))
-def camera(name, device_id, start_ffmpeg, action):
+@click.option('--offer-file', required=False, type=click.Path(exists=True),
+              help='file containing a WebRTC offer SDP, for start-sip-stream')
+@click.option('--answer-file', required=False, type=click.Path(),
+              help='file to write the SIP answer SDP to, for start-sip-stream')
+@click.argument('action', type=click.Choice(
+    ['start-stream', 'stop-stream', 'last-thumbnail', 'sip-info', 'start-sip-stream'], case_sensitive=False))
+def camera(name, device_id, start_ffmpeg, offer_file, answer_file, action):
     camera = None
     ar = login()
     for c in ar.cameras:
@@ -402,6 +420,38 @@ def camera(name, device_id, start_ffmpeg, action):
             print("last-thumbnail={}".format(last_thumbnail))
         else:
             print(' error getting thumbnail')
+
+    elif action == 'sip-info':
+        print('opening SIP signaling (diagnostic only - checks whether this '
+              'camera speaks SIP/WebRTC at all; does not start a call)')
+        info = camera.get_sip_info()
+        print('ice-servers={}'.format(info['ice_servers']))
+        camera.stop_sip_stream()
+
+    elif action == 'start-sip-stream':
+        if offer_file is None:
+            print('--offer-file is required for start-sip-stream '
+                  '(a WebRTC offer SDP from your own peer connection)')
+            return 0
+        with open(offer_file, 'r') as f:
+            offer_sdp = f.read()
+
+        print('opening SIP signaling')
+        camera.get_sip_info()
+        print('negotiating call')
+        answer_sdp = camera.start_sip_stream(offer_sdp)
+
+        if answer_file is not None:
+            with open(answer_file, 'w') as f:
+                f.write(answer_sdp)
+            print('answer-sdp written to {}'.format(answer_file))
+        else:
+            print('answer-sdp:\n{}'.format(answer_sdp))
+
+        # This CLI is a signaling diagnostic, not a player - it has no
+        # media stack to hand the answer to, so there's nothing further to
+        # keep the call open for.
+        camera.stop_sip_stream()
 
 
 def main_func():

--- a/pyaarlo/sdp.py
+++ b/pyaarlo/sdp.py
@@ -1,0 +1,95 @@
+"""Pure SDP repair helpers for the SIP/WebRTC signaling path.
+
+Arlo's SIP proxy is fussy about the offers it accepts and sloppy about the
+answers it returns. These functions patch both directions. They do no I/O and
+have no dependency on the rest of pyaarlo, so they're plain unit-testable.
+"""
+
+CANDIDATE_PREFIX = "a=candidate:"
+MID_PREFIX = "a=mid:"
+DIRECTION_PREFIXES = ("a=send", "a=recv")
+END_OF_CANDIDATES_LINE = "a=end-of-candidates"
+
+
+def _split_lines(sdp):
+    return [line.strip() for line in sdp.replace("\r\n", "\n").split("\n") if line.strip() != ""]
+
+
+def _join_lines(lines):
+    # RFC 4566 terminates every line, including the last, with CRLF. A
+    # bare "\r\n".join(...) leaves the final line unterminated - harmless
+    # to most parsers, but Chrome's rejects exactly that line outright
+    # ("Failed to parse SessionDescription... Invalid SDP line") when it's
+    # also the last line of the whole message.
+    if not lines:
+        return ""
+    return "\r\n".join(lines) + "\r\n"
+
+
+def filter_offer_candidates(sdp):
+    """Strip ICE candidates Arlo's SIP proxy rejects.
+
+    Removes IPv6 candidates (recognized by a second `:` beyond the
+    `a=candidate:` prefix) and mDNS `.local` candidates. Without this filter
+    the INVITE is accepted but negotiation silently fails to connect.
+    """
+    lines = []
+    for line in _split_lines(sdp):
+        if line.startswith(CANDIDATE_PREFIX):
+            if line.count(":") <= 1 and ".local" not in line:
+                lines.append(line)
+        else:
+            lines.append(line)
+    return _join_lines(lines)
+
+
+def clean_answer(sdp):
+    """Repair the SDP answer Arlo's SIP proxy returns.
+
+    Arlo omits `a=mid` and direction attributes on its answer, which most
+    WebRTC peers reject outright. This inserts, immediately after each `m=`
+    line, whatever of `a=mid:<n>` / `a=sendrecv` (audio) / `a=sendonly`
+    (video) is missing.
+
+    Also drops `a=end-of-candidates` (RFC 8840): it signals that trickle
+    ICE has finished sending candidates, which is meaningless here - this
+    module never trickles, it exchanges one complete offer/answer pair -
+    and Chrome's SDP parser rejects it outright wherever Arlo places it.
+    """
+    result = []
+    section = None
+    section_lines = []
+
+    def flush_section():
+        if section is None:
+            return
+        has_mid = any(line.startswith(MID_PREFIX) for line in section_lines)
+        has_direction = any(
+            line.startswith(DIRECTION_PREFIXES) for line in section_lines
+        )
+        if not has_mid:
+            result.append(MID_PREFIX + ("0" if section == "audio" else "1"))
+        if not has_direction:
+            result.append("a=sendrecv" if section == "audio" else "a=sendonly")
+        result.extend(section_lines)
+
+    for line in _split_lines(sdp):
+        if line == END_OF_CANDIDATES_LINE:
+            continue
+        if line.startswith("m="):
+            flush_section()
+            section_lines = []
+            if line.startswith("m=audio"):
+                section = "audio"
+            elif line.startswith("m=video"):
+                section = "video"
+            else:
+                section = None
+            result.append(line)
+        elif section is not None:
+            section_lines.append(line)
+        else:
+            result.append(line)
+    flush_section()
+
+    return _join_lines(result)

--- a/pyaarlo/sip.py
+++ b/pyaarlo/sip.py
@@ -1,0 +1,735 @@
+"""SIP-over-WebSocket signaling for Arlo's live-streaming path.
+
+Arlo's official apps - including my.arlo.com in a browser - negotiate live
+video over WebRTC, signaled through a small, fixed set of SIP messages sent
+over a WebSocket. This module reimplements just that signaling leg: it takes
+a caller-supplied WebRTC offer SDP and returns Arlo's answer SDP. It never
+touches media - on the streaming path, Arlo's own SIP proxy doesn't either
+(see the module docstring on `ArloSip` for why that's true and where it
+comes from).
+
+This is intentionally not a general SIP stack. The message set Arlo's proxy
+needs is exactly INVITE / ACK / MESSAGE / BYE, so those are hand-built and
+hand-parsed rather than pulled in via a third-party SIP library.
+"""
+
+import hashlib
+import random
+import re
+import string
+import threading
+import time
+import uuid
+from enum import Enum
+from queue import Empty, Queue
+
+import websocket
+
+from .constant import ORIGIN_HOST, SIP_INFO_V2_PATH, USER_AGENTS
+from .sdp import clean_answer, filter_offer_candidates
+
+WS_PORT = 7443
+DEFAULT_TIMEOUT = 5
+DEFAULT_KEEPALIVE_INTERVAL = 30
+SIP_USER_AGENT = "SIP.js/0.21.1"
+
+_RAND_ALPHABET = string.ascii_lowercase + string.digits
+
+
+class ArloSipError(Exception):
+    """Base class for all SIP signaling errors."""
+
+
+class ArloSipAuthError(ArloSipError):
+    """Raised when SIP digest authentication fails or is unsupported."""
+
+
+class ArloSipTimeout(ArloSipError):
+    """Raised when a SIP transaction gets no final response in time."""
+
+
+class ArloSipProtocolError(ArloSipError):
+    """Raised when Arlo's SIP proxy returns something unparsable or unexpected."""
+
+
+class SipState(Enum):
+    IDLE = "idle"
+    CONNECTING = "connecting"
+    AUTHENTICATING = "authenticating"
+    ESTABLISHED = "established"
+    CLOSING = "closing"
+    CLOSED = "closed"
+    FAILED = "failed"
+    RECONNECTING = "reconnecting"
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers - no I/O, no shared state, fully unit-testable.
+# ---------------------------------------------------------------------------
+
+
+def _rand_string(length):
+    return "".join(random.choice(_RAND_ALPHABET) for _ in range(length))
+
+
+def _rand_digits(length):
+    return "".join(random.choice(string.digits) for _ in range(length))
+
+
+def gen_branch():
+    return "z9hG4bK" + _rand_digits(7)
+
+
+def gen_tag():
+    return _rand_string(8)
+
+
+def gen_call_id():
+    return uuid.uuid4().hex
+
+
+def gen_contact_host():
+    return _rand_string(12) + ".invalid"
+
+
+def _md5(*parts):
+    return hashlib.md5(":".join(parts).encode("utf-8")).hexdigest()
+
+
+class SipMessage(object):
+    """A single SIP request or response.
+
+    Headers are kept as an ordered list of (name, value) pairs rather than a
+    dict, since SIP allows repeated headers (`Via`, `Record-Route`) and
+    order matters on the wire.
+    """
+
+    def __init__(self, start_line, headers=None, body=""):
+        self.start_line = start_line
+        self.headers = list(headers) if headers else []
+        self.body = body
+
+    def add_header(self, name, value):
+        self.headers.append((name, value))
+
+    def get_header(self, name):
+        name = name.lower()
+        for hname, hvalue in self.headers:
+            if hname.lower() == name:
+                return hvalue
+        return None
+
+    def get_headers(self, name):
+        name = name.lower()
+        return [hvalue for hname, hvalue in self.headers if hname.lower() == name]
+
+    @property
+    def is_response(self):
+        return self.start_line.startswith("SIP/2.0")
+
+    @property
+    def status_code(self):
+        if not self.is_response:
+            return None
+        return int(self.start_line.split(" ", 2)[1])
+
+    @property
+    def method(self):
+        if self.is_response:
+            cseq = self.get_header("CSeq")
+            if not cseq:
+                return None
+            parts = cseq.split()
+            return parts[1] if len(parts) > 1 else None
+        return self.start_line.split(" ", 1)[0]
+
+    @property
+    def cseq_number(self):
+        cseq = self.get_header("CSeq")
+        if not cseq:
+            return None
+        return int(cseq.split()[0])
+
+    def to_wire(self):
+        lines = [self.start_line]
+        body_bytes = self.body.encode("utf-8")
+        for name, value in self.headers:
+            lines.append(f"{name}: {value}")
+        lines.append(f"Content-Length: {len(body_bytes)}")
+        return "\r\n".join(lines) + "\r\n\r\n" + self.body
+
+    @classmethod
+    def parse(cls, raw):
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", errors="replace")
+        head, _, body = raw.partition("\r\n\r\n")
+        lines = head.split("\r\n")
+        if not lines or not lines[0]:
+            raise ArloSipProtocolError("empty SIP message")
+        start_line = lines[0]
+        headers = []
+        for line in lines[1:]:
+            if not line:
+                continue
+            name, sep, value = line.partition(":")
+            if not sep:
+                continue
+            headers.append((name.strip(), value.strip()))
+        message = cls(start_line, headers, body)
+        content_length = message.get_header("Content-Length")
+        if content_length is not None:
+            try:
+                message.body = body[: int(content_length)]
+            except ValueError:
+                pass
+        return message
+
+
+class AuthHeader(object):
+    """A SIP `Proxy-Authenticate` / `Proxy-Authorization` header.
+
+    Only MD5 digest with `qop=auth` is supported - the only scheme Arlo's
+    SIP proxy has been observed to request.
+    """
+
+    UNQUOTED_PARAMS = ("algorithm", "qop", "nc")
+
+    def __init__(self, mode="Digest", params=None):
+        self.mode = mode
+        self.params = dict(params) if params else {}
+
+    @classmethod
+    def parse(cls, value):
+        if value is None:
+            raise ArloSipProtocolError("missing Proxy-Authenticate header")
+        mode, _, rest = value.partition(" ")
+        params = {}
+        for name, raw_value in re.findall(r'(\w+)=("[^"]*"|[^,]+)', rest):
+            params[name] = raw_value.strip().strip('"')
+        return cls(mode, params)
+
+    def __str__(self):
+        rendered = []
+        for key, value in self.params.items():
+            if key in self.UNQUOTED_PARAMS:
+                rendered.append(f"{key}={value}")
+            else:
+                rendered.append(f'{key}="{value}"')
+        return f"{self.mode} {', '.join(rendered)}"
+
+    def compute_response(self, method, uri, username, password):
+        """Fills in `username`, `uri`, `cnonce`, `nc` and `response` for a
+        qop=auth MD5 digest, given the challenge parameters already parsed
+        into `self.params` (`realm`, `nonce`, and optionally `algorithm`).
+        """
+        algorithm = self.params.get("algorithm", "MD5")
+        if algorithm != "MD5":
+            raise ArloSipAuthError(f"unsupported digest algorithm: {algorithm}")
+        if self.params.get("qop") != "auth":
+            raise ArloSipAuthError(f"unsupported qop: {self.params.get('qop')}")
+        if "realm" not in self.params or "nonce" not in self.params:
+            raise ArloSipAuthError("challenge is missing realm or nonce")
+
+        self.params["username"] = username
+        self.params["uri"] = uri
+        self.params.setdefault("cnonce", _rand_string(12))
+        self.params.setdefault("nc", "00000001")
+
+        ha1 = _md5(username, self.params["realm"], password)
+        ha2 = _md5(method, uri)
+        self.params["response"] = _md5(
+            ha1,
+            self.params["nonce"],
+            self.params["nc"],
+            self.params["cnonce"],
+            self.params["qop"],
+            ha2,
+        )
+        return self.params["response"]
+
+
+# ---------------------------------------------------------------------------
+# Message builders - pure functions of their arguments, no randomness unless
+# the caller omits an id (in which case the module-level generators above
+# are used, keeping tests able to pin every value explicitly).
+# ---------------------------------------------------------------------------
+
+ALLOW_HEADER = "ACK,CANCEL,INVITE,MESSAGE,BYE,OPTIONS,INFO,NOTIFY,REFER"
+
+
+def build_invite(
+    caller_uri,
+    callee_uri,
+    contact_host,
+    device_id,
+    sdp,
+    user_agent,
+    call_id,
+    tag,
+    contact_user,
+    cseq=1,
+    branch=None,
+    proxy_authorization=None,
+):
+    branch = branch or gen_branch()
+    message = SipMessage(f"INVITE {callee_uri} SIP/2.0")
+    message.add_header("Via", f"SIP/2.0/WSS {contact_host};branch={branch}")
+    message.add_header("Max-Forwards", "70")
+    message.add_header("From", f'"WebRTC-UDP" <{caller_uri}>;tag={tag}')
+    message.add_header("To", f"<{callee_uri}>")
+    message.add_header("Call-ID", call_id)
+    message.add_header("CSeq", f"{cseq} INVITE")
+    message.add_header("Contact", f"<sip:{contact_user}@{contact_host};transport=ws;ob>")
+    message.add_header("Allow", ALLOW_HEADER)
+    message.add_header("Supported", "outbound")
+    message.add_header("User-Agent", user_agent)
+    # This is what routes the call to the specific camera - the proxy has no
+    # other way to tell which device on the account should pick up.
+    message.add_header("X-extension", f"{device_id}; User-Agent: webrtc")
+    if proxy_authorization is not None:
+        message.add_header("Proxy-Authorization", proxy_authorization)
+    message.add_header("Content-Type", "application/sdp")
+    message.body = sdp
+    return message
+
+
+def build_ack_from_response(response, callee_uri, contact_host, user_agent):
+    """Builds the ACK for a response to INVITE.
+
+    Reuses the response's Call-ID, CSeq number, and its From/To headers
+    verbatim (they already carry the tags both sides agreed on), and turns
+    any Record-Route headers into a reversed Route set, per RFC 3261.
+    """
+    message = SipMessage(f"ACK {callee_uri} SIP/2.0")
+    message.add_header("Via", f"SIP/2.0/WSS {contact_host};branch={gen_branch()}")
+    message.add_header("Max-Forwards", "70")
+    message.add_header("From", response.get_header("From"))
+    message.add_header("To", response.get_header("To"))
+    for route in reversed(response.get_headers("Record-Route")):
+        message.add_header("Route", route)
+    message.add_header("Call-ID", response.get_header("Call-ID"))
+    message.add_header("CSeq", f"{response.cseq_number} ACK")
+    message.add_header("Supported", "outbound")
+    message.add_header("User-Agent", user_agent)
+    return message
+
+
+def build_bye_from_response(response, callee_uri, contact_host, user_agent):
+    """Builds a BYE that closes the dialog established by `response`.
+
+    Same shape as the matching ACK (same dialog identifiers, reversed
+    Route set) but with its own CSeq, one past the response's.
+    """
+    message = build_ack_from_response(response, callee_uri, contact_host, user_agent)
+    message.start_line = f"BYE {callee_uri} SIP/2.0"
+    message.headers = [(name, value) for name, value in message.headers if name.lower() != "cseq"]
+    message.add_header("CSeq", f"{response.cseq_number + 1} BYE")
+    return message
+
+
+def build_message(caller_uri, callee_uri, contact_host, payload, user_agent):
+    """Builds a SIP MESSAGE request - each one is its own fresh dialog."""
+    message = SipMessage(f"MESSAGE {callee_uri} SIP/2.0")
+    message.add_header("Via", f"SIP/2.0/WSS {contact_host};branch={gen_branch()}")
+    message.add_header("Max-Forwards", "70")
+    message.add_header("From", f"<{caller_uri}>;tag={gen_tag()}")
+    message.add_header("To", f"<{callee_uri}>")
+    message.add_header("Call-ID", gen_call_id())
+    message.add_header("CSeq", "1 MESSAGE")
+    message.add_header("Supported", "outbound")
+    message.add_header("User-Agent", user_agent)
+    message.add_header("Content-Type", "text/plain")
+    message.body = payload
+    return message
+
+
+# ---------------------------------------------------------------------------
+# The stateful client.
+# ---------------------------------------------------------------------------
+
+
+class ArloSip(object):
+    """SIP-over-WebSocket signaling client for Arlo's live-streaming path.
+
+    On this path Arlo's own SIP helper is documented (in the third-party Go
+    client this was reverse-engineered against) as pure signaling: "if an
+    SDP is provided, it is assumed that the caller will manage the media
+    traffic, and this SIP client is only used to manage signaling." This
+    class does exactly that - it takes an offer SDP the caller already built
+    against `ice_servers`, and returns Arlo's answer SDP. It never creates a
+    peer connection and never sees a media packet.
+
+    One instance is one call attempt - it is not reused across streams.
+    Not thread-safe for concurrent callers; internally it runs a dedicated
+    reader thread and (once established) a keepalive thread, both daemon
+    threads distinct from pyaarlo's shared background worker.
+
+    Usage::
+
+        sip = ArloSip(arlo, camera)
+        sip.connect()                    # fetches sipCallInfo + iceServers, opens the websocket
+        offer = build_offer(sip.ice_servers)   # caller's own WebRTC stack
+        answer = sip.start(offer)        # INVITE / digest auth / ACK -> Arlo's answer SDP
+        ...
+        sip.close()
+    """
+
+    def __init__(
+        self,
+        arlo,
+        camera,
+        timeout=None,
+        keepalive_interval=None,
+        sip_user_agent=None,
+        ws_user_agent=None,
+        ws_port=None,
+    ):
+        self._arlo = arlo
+        self._camera = camera
+        self._timeout = timeout or DEFAULT_TIMEOUT
+        self._keepalive_interval = keepalive_interval or DEFAULT_KEEPALIVE_INTERVAL
+        self._sip_user_agent = sip_user_agent or SIP_USER_AGENT
+        self._ws_user_agent = ws_user_agent or USER_AGENTS["firefox"]
+        self._ws_port = ws_port or WS_PORT
+
+        self._state = SipState.IDLE
+        self._state_lock = threading.RLock()
+
+        self._ws = None
+        self._send_lock = threading.Lock()
+        self._reader_thread = None
+        self._keepalive_thread = None
+        self._stop_event = threading.Event()
+
+        self._pending = {}
+        self._pending_lock = threading.Lock()
+
+        self._sip_info = None
+        self._caller_uri = None
+        self._callee_uri = None
+        self._username = None
+        self._password = None
+        self._contact_host = gen_contact_host()
+        self._contact_user = _rand_string(8)
+        self._call_id = None
+        self._tag = None
+        self._cseq = 1
+        self._last_response = None
+
+    # -- state -------------------------------------------------------------
+
+    @property
+    def state(self):
+        with self._state_lock:
+            return self._state
+
+    def _set_state(self, state):
+        with self._state_lock:
+            self._arlo.debug(f"sip: {self._camera.device_id}: {self._state.value} -> {state.value}")
+            self._state = state
+
+    # -- bootstrap -----------------------------------------------------------
+
+    def _fetch_sip_info(self):
+        params = {
+            "cameraId": self._camera.device_id,
+            "modelId": (self._camera.model_id or "").upper(),
+            "uniqueId": self._camera.unique_id,
+        }
+        headers = {
+            "xcloudId": self._camera.xcloud_id,
+            "cameraId": self._camera.device_id,
+        }
+        # No raw=True here: unlike the capabilities document (a static file,
+        # no envelope), sipInfo/v2 is a normal /hmsweb/ endpoint wrapped in
+        # Arlo's {"success": ..., "data": {...}} envelope, which pyaarlo's
+        # backend already unwraps for us by default.
+        response = self._arlo.be.get(SIP_INFO_V2_PATH, params=params, headers=headers)
+        if not isinstance(response, dict) or "sipCallInfo" not in response:
+            raise ArloSipProtocolError(
+                f"no sipInfo for camera {self._camera.device_id}: got {response!r}"
+            )
+        return response
+
+    @property
+    def ice_servers(self):
+        """Returns Arlo's published ICE servers, shaped for an RTCConfiguration.
+
+        `[]` until `fetch_info()` (or `connect()`, which calls it) has run.
+        """
+        if self._sip_info is None:
+            return []
+        servers = []
+        for entry in self._sip_info.get("iceServers", {}).get("data", []):
+            servers.append(
+                {
+                    "urls": [f"{entry['type']}:{entry['domain']}:{entry['port']}"],
+                    "username": entry.get("username"),
+                    "credential": entry.get("credential"),
+                }
+            )
+        return servers
+
+    def fetch_info(self):
+        """Fetches the SIP credentials and ICE servers over REST only.
+
+        Split out from `connect()` because a caller needs `ice_servers`
+        *before* it can build the offer SDP, and the gap between the two can
+        be seconds long - a browser gathering ICE candidates, say. Opening
+        the websocket that early would just leave it idle for that whole
+        window. Idempotent; the result is cached on the instance.
+        """
+        if self._sip_info is not None:
+            return self._sip_info
+
+        sip_info = self._fetch_sip_info()
+        call_info = sip_info["sipCallInfo"]
+        domain = call_info["domain"]
+
+        self._username = call_info["id"]
+        self._password = call_info["password"]
+        self._caller_uri = f"sip:{call_info['id']}@{domain}:{self._ws_port}"
+        self._callee_uri = call_info["calleeUri"]
+        self._sip_info = sip_info
+        return sip_info
+
+    def ensure_connected(self):
+        """Opens the signaling websocket unless it's already open."""
+        if self.state == SipState.IDLE:
+            self.connect()
+
+    def connect(self):
+        """Fetches SIP credentials if needed, then opens the signaling websocket."""
+        if self.state != SipState.IDLE:
+            raise ArloSipError(f"cannot connect from state {self.state.value}")
+        try:
+            self._set_state(SipState.CONNECTING)
+            self.fetch_info()
+            domain = self._sip_info["sipCallInfo"]["domain"]
+
+            url = f"wss://{domain}:{self._ws_port}"
+            self._arlo.debug(f"sip: connecting to {url}")
+            self._ws = websocket.create_connection(
+                url,
+                subprotocols=["sip"],
+                origin=ORIGIN_HOST,
+                header=[f"User-Agent: {self._ws_user_agent}"],
+                timeout=self._timeout,
+            )
+            self._stop_event.clear()
+            self._reader_thread = threading.Thread(
+                target=self._reader_loop, name=f"ArloSipReader-{self._camera.device_id}", daemon=True
+            )
+            self._reader_thread.start()
+        except ArloSipError:
+            self._set_state(SipState.FAILED)
+            self.close()
+            raise
+        except Exception as e:
+            self._set_state(SipState.FAILED)
+            self.close()
+            raise ArloSipError(f"connect failed: {type(e).__name__}: {e}") from e
+
+    # -- reader thread -------------------------------------------------------
+
+    def _reader_loop(self):
+        while not self._stop_event.is_set():
+            try:
+                raw = self._ws.recv()
+            except websocket.WebSocketTimeoutException:
+                continue
+            except Exception as e:
+                self._arlo.debug(f"sip: {self._camera.device_id}: reader stopped: {type(e).__name__}")
+                break
+            if not raw:
+                continue
+            try:
+                message = SipMessage.parse(raw)
+            except ArloSipProtocolError as e:
+                self._arlo.debug(f"sip: {self._camera.device_id}: unparsable message: {e}")
+                continue
+            self._dispatch(message)
+
+    def _dispatch(self, message):
+        if not message.is_response:
+            self._arlo.debug(f"sip: {self._camera.device_id}: dropping unexpected request {message.start_line}")
+            return
+        key = (message.get_header("Call-ID"), message.cseq_number, message.method)
+        with self._pending_lock:
+            queue = self._pending.get(key)
+        if queue is None:
+            self._arlo.vdebug(f"sip: {self._camera.device_id}: dropping unmatched response {message.start_line}")
+            return
+        queue.put(message)
+
+    # -- transactions --------------------------------------------------------
+
+    def _send(self, message):
+        with self._send_lock:
+            if self._ws is None:
+                raise ArloSipError("not connected")
+            self._ws.send(message.to_wire())
+
+    def _send_and_wait(self, message, timeout=None):
+        """Sends a request and waits for its final (non-1xx) response.
+
+        Registration happens before the send so a fast reply can never
+        race ahead of us starting to listen for it.
+        """
+        timeout = timeout or self._timeout
+        key = (message.get_header("Call-ID"), message.cseq_number, message.method)
+        queue = Queue()
+        with self._pending_lock:
+            self._pending[key] = queue
+        try:
+            self._send(message)
+            deadline = time.monotonic() + timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ArloSipTimeout(f"no response to {message.method} within {timeout}s")
+                try:
+                    response = queue.get(timeout=remaining)
+                except Empty:
+                    raise ArloSipTimeout(f"no response to {message.method} within {timeout}s")
+                if response.status_code < 200:
+                    continue
+                return response
+        finally:
+            with self._pending_lock:
+                self._pending.pop(key, None)
+
+    # -- call setup -----------------------------------------------------------
+
+    def start(self, offer_sdp):
+        """Negotiates the call and returns Arlo's (repaired) answer SDP.
+
+        `offer_sdp` must already be a complete WebRTC offer built by the
+        caller's own peer connection against `ice_servers` - this class
+        does not create one.
+        """
+        if self.state != SipState.CONNECTING:
+            raise ArloSipError(f"cannot start from state {self.state.value}; call connect() first")
+        try:
+            self._set_state(SipState.AUTHENTICATING)
+
+            offer_sdp = filter_offer_candidates(offer_sdp)
+            self._call_id = gen_call_id()
+            self._tag = gen_tag()
+
+            invite = build_invite(
+                self._caller_uri,
+                self._callee_uri,
+                self._contact_host,
+                self._camera.device_id,
+                offer_sdp,
+                self._sip_user_agent,
+                call_id=self._call_id,
+                tag=self._tag,
+                contact_user=self._contact_user,
+                cseq=self._cseq,
+            )
+            response = self._send_and_wait(invite)
+
+            if response.status_code == 407:
+                self._send(build_ack_from_response(response, self._callee_uri, self._contact_host, self._sip_user_agent))
+
+                challenge = AuthHeader.parse(response.get_header("Proxy-Authenticate"))
+                challenge.compute_response("INVITE", self._callee_uri, self._username, self._password)
+
+                self._cseq += 1
+                invite = build_invite(
+                    self._caller_uri,
+                    self._callee_uri,
+                    self._contact_host,
+                    self._camera.device_id,
+                    offer_sdp,
+                    self._sip_user_agent,
+                    call_id=self._call_id,
+                    tag=self._tag,
+                    contact_user=self._contact_user,
+                    cseq=self._cseq,
+                    proxy_authorization=str(challenge),
+                )
+                response = self._send_and_wait(invite)
+
+            if response.status_code != 200:
+                raise ArloSipProtocolError(f"INVITE rejected: {response.start_line}")
+            if "application/sdp" not in (response.get_header("Content-Type") or ""):
+                raise ArloSipProtocolError("200 OK did not carry an SDP answer")
+
+            self._last_response = response
+            self._send(build_ack_from_response(response, self._callee_uri, self._contact_host, self._sip_user_agent))
+
+            answer_sdp = clean_answer(response.body)
+
+            self._start_keepalive()
+            self._set_state(SipState.ESTABLISHED)
+            return answer_sdp
+        except ArloSipError:
+            self._set_state(SipState.FAILED)
+            self.close()
+            raise
+
+    # -- keepalive -------------------------------------------------------------
+
+    def _start_keepalive(self):
+        self._keepalive_thread = threading.Thread(
+            target=self._keepalive_loop, name=f"ArloSipKeepalive-{self._camera.device_id}", daemon=True
+        )
+        self._keepalive_thread.start()
+
+    def _keepalive_loop(self):
+        while not self._stop_event.wait(self._keepalive_interval):
+            if self.state != SipState.ESTABLISHED:
+                return
+            try:
+                message = build_message(
+                    self._caller_uri, self._callee_uri, self._contact_host, "keepAlive", self._sip_user_agent
+                )
+                response = self._send_and_wait(message)
+                if response.status_code != 202:
+                    raise ArloSipProtocolError(f"keepAlive rejected: {response.start_line}")
+            except ArloSipError as e:
+                self._arlo.debug(f"sip: {self._camera.device_id}: keepalive failed, closing: {e}")
+                self._set_state(SipState.FAILED)
+                self.close()
+                return
+
+    # -- teardown ---------------------------------------------------------------
+
+    def close(self):
+        """Idempotent teardown: BYE if a dialog was established, close the
+        websocket, stop and join both threads. Safe to call from any state,
+        including after a failed `connect()`/`start()`.
+        """
+        with self._state_lock:
+            if self._state in (SipState.CLOSED, SipState.CLOSING):
+                return
+            established = self._state == SipState.ESTABLISHED
+            self._state = SipState.CLOSING
+
+        self._stop_event.set()
+
+        if established and self._last_response is not None:
+            try:
+                bye = build_bye_from_response(
+                    self._last_response, self._callee_uri, self._contact_host, self._sip_user_agent
+                )
+                self._send(bye)
+            except ArloSipError as e:
+                self._arlo.debug(f"sip: {self._camera.device_id}: could not send BYE: {e}")
+
+        if self._ws is not None:
+            try:
+                self._ws.close()
+            except Exception:
+                pass
+
+        current = threading.current_thread()
+        if self._keepalive_thread is not None and self._keepalive_thread is not current and self._keepalive_thread.is_alive():
+            self._keepalive_thread.join(timeout=self._timeout)
+        if self._reader_thread is not None and self._reader_thread is not current and self._reader_thread.is_alive():
+            self._reader_thread.join(timeout=self._timeout)
+
+        self._set_state(SipState.CLOSED)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ curl_cffi
 paho-mqtt
 cryptography
 python-slugify
+websocket-client

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
         'curl_cffi',
         'paho-mqtt',
         'cryptography',
-        'python-slugify'
+        'python-slugify',
+        'websocket-client'
     ],
 
     author='Steve Herrell',

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -1,0 +1,166 @@
+from unittest import TestCase
+
+from pyaarlo.sdp import clean_answer, filter_offer_candidates
+
+
+class TestFilterOfferCandidates(TestCase):
+    def test_keeps_ipv4_host_candidate(self):
+        sdp = (
+            "v=0\r\n"
+            "a=candidate:1467250027 1 udp 2122260223 192.168.1.5 51673 typ host generation 0\r\n"
+        )
+        out = filter_offer_candidates(sdp)
+        self.assertIn("a=candidate:1467250027 1 udp 2122260223 192.168.1.5 51673 typ host generation 0", out)
+
+    def test_drops_ipv6_candidate(self):
+        sdp = (
+            "v=0\r\n"
+            "a=candidate:1 1 udp 2122260223 2001:db8::1 51673 typ host generation 0\r\n"
+            "a=candidate:2 1 udp 2122260223 192.168.1.5 51673 typ host generation 0\r\n"
+        )
+        out = filter_offer_candidates(sdp)
+        self.assertNotIn("2001:db8::1", out)
+        self.assertIn("192.168.1.5", out)
+
+    def test_drops_mdns_local_candidate(self):
+        sdp = (
+            "v=0\r\n"
+            "a=candidate:1 1 udp 2122260223 8f3ecc46-1234-4a2f-9999-abcdefabcdef.local 51673 typ host generation 0\r\n"
+            "a=candidate:2 1 udp 2122260223 192.168.1.5 51673 typ host generation 0\r\n"
+        )
+        out = filter_offer_candidates(sdp)
+        self.assertNotIn(".local", out)
+        self.assertIn("192.168.1.5", out)
+
+    def test_keeps_non_candidate_lines_untouched(self):
+        sdp = "v=0\r\no=- 123 456 IN IP4 0.0.0.0\r\ns=-\r\n"
+        out = filter_offer_candidates(sdp)
+        self.assertIn("o=- 123 456 IN IP4 0.0.0.0", out)
+        self.assertIn("s=-", out)
+
+    def test_normalizes_bare_lf_to_crlf(self):
+        sdp = "v=0\no=- 123 456 IN IP4 0.0.0.0\n"
+        out = filter_offer_candidates(sdp)
+        self.assertEqual(out, "v=0\r\no=- 123 456 IN IP4 0.0.0.0\r\n")
+
+    def test_ends_with_a_trailing_crlf(self):
+        # RFC 4566 terminates every line, including the last, with CRLF.
+        # Chrome's SDP parser enforces this - an unterminated last line
+        # gets rejected outright ("Invalid SDP line"), which is exactly
+        # what happened before this was fixed.
+        sdp = "v=0\r\na=candidate:1 1 udp 2122260223 192.168.1.5 51673 typ host generation 0\r\n"
+        out = filter_offer_candidates(sdp)
+        self.assertTrue(out.endswith("\r\n"))
+        self.assertFalse(out.endswith("\r\n\r\n"))
+
+    def test_empty_input(self):
+        self.assertEqual(filter_offer_candidates(""), "")
+
+
+class TestCleanAnswer(TestCase):
+    ARLO_ANSWER = (
+        "v=0\r\n"
+        "o=- 123 456 IN IP4 0.0.0.0\r\n"
+        "s=-\r\n"
+        "t=0 0\r\n"
+        "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=rtpmap:111 opus/48000/2\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 96\r\n"
+        "c=IN IP4 0.0.0.0\r\n"
+        "a=rtpmap:96 H264/90000\r\n"
+    )
+
+    def test_inserts_missing_mid_and_direction(self):
+        out = clean_answer(self.ARLO_ANSWER)
+        lines = out.split("\r\n")
+
+        audio_idx = lines.index("m=audio 9 UDP/TLS/RTP/SAVPF 111")
+        self.assertEqual(lines[audio_idx + 1], "a=mid:0")
+        self.assertEqual(lines[audio_idx + 2], "a=sendrecv")
+
+        video_idx = lines.index("m=video 9 UDP/TLS/RTP/SAVPF 96")
+        self.assertEqual(lines[video_idx + 1], "a=mid:1")
+        self.assertEqual(lines[video_idx + 2], "a=sendonly")
+
+    def test_leaves_existing_mid_untouched(self):
+        sdp = (
+            "v=0\r\n"
+            "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+            "a=mid:0\r\n"
+            "a=sendrecv\r\n"
+            "a=rtpmap:111 opus/48000/2\r\n"
+        )
+        out = clean_answer(sdp)
+        # Only one a=mid:0 and one a=sendrecv should be present - no duplicate insertion.
+        self.assertEqual(out.count("a=mid:0"), 1)
+        self.assertEqual(out.count("a=sendrecv"), 1)
+
+    def test_leaves_existing_direction_untouched(self):
+        sdp = (
+            "v=0\r\n"
+            "m=video 9 UDP/TLS/RTP/SAVPF 96\r\n"
+            "a=recvonly\r\n"
+            "a=rtpmap:96 H264/90000\r\n"
+        )
+        out = clean_answer(sdp)
+        self.assertIn("a=recvonly", out)
+        self.assertNotIn("a=sendonly", out)
+        self.assertIn("a=mid:1", out)
+
+    def test_preamble_lines_untouched(self):
+        out = clean_answer(self.ARLO_ANSWER)
+        self.assertTrue(out.startswith("v=0\r\no=- 123 456 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\n"))
+
+    def test_audio_only_answer(self):
+        sdp = "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=rtpmap:111 opus/48000/2\r\n"
+        out = clean_answer(sdp)
+        lines = out.split("\r\n")
+        audio_idx = lines.index("m=audio 9 UDP/TLS/RTP/SAVPF 111")
+        self.assertEqual(lines[audio_idx + 1], "a=mid:0")
+        self.assertEqual(lines[audio_idx + 2], "a=sendrecv")
+
+    def test_drops_end_of_candidates_at_session_level(self):
+        # Real-world case: Arlo's answer rejected by Chrome with
+        # "Failed to parse SessionDescription. a=end-of-candidates Invalid SDP line."
+        sdp = "v=0\r\na=end-of-candidates\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=rtpmap:111 opus/48000/2\r\n"
+        out = clean_answer(sdp)
+        self.assertNotIn("a=end-of-candidates", out)
+
+    def test_drops_end_of_candidates_at_media_level(self):
+        sdp = (
+            "v=0\r\n"
+            "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+            "a=rtpmap:111 opus/48000/2\r\n"
+            "a=end-of-candidates\r\n"
+            "m=video 9 UDP/TLS/RTP/SAVPF 96\r\n"
+            "a=rtpmap:96 H264/90000\r\n"
+            "a=end-of-candidates\r\n"
+        )
+        out = clean_answer(sdp)
+        self.assertNotIn("a=end-of-candidates", out)
+        # the rest of each section must survive the drop
+        self.assertIn("a=rtpmap:111 opus/48000/2", out)
+        self.assertIn("a=rtpmap:96 H264/90000", out)
+
+    def test_empty_input(self):
+        self.assertEqual(clean_answer(""), "")
+
+    def test_ends_with_a_trailing_crlf(self):
+        # Real-world case: Arlo's video section ends with its host
+        # candidate as the very last line of the entire SDP, with no
+        # terminator. Chrome's parser rejected exactly that line -
+        # "Failed to parse SessionDescription. a=candidate:... Invalid
+        # SDP line." - because it was left unterminated by a bare
+        # "\r\n".join(...).
+        sdp = (
+            "v=0\r\n"
+            "m=video 30264 UDP/TLS/RTP/SAVPF 102\r\n"
+            "a=mid:1\r\n"
+            "a=sendonly\r\n"
+            "a=ice-ufrag:NZtDjwDqBKiMQhEE\r\n"
+            "a=candidate:4124236056 1 udp 2130706431 34.245.199.120 30264 typ host generation 0"
+        )
+        out = clean_answer(sdp)
+        self.assertTrue(out.endswith("typ host generation 0\r\n"))
+        self.assertFalse(out.endswith("\r\n\r\n"))

--- a/tests/test_sip_messages.py
+++ b/tests/test_sip_messages.py
@@ -1,0 +1,478 @@
+from unittest import TestCase
+
+from pyaarlo.sip import (
+    ArloSip,
+    ArloSipAuthError,
+    ArloSipError,
+    ArloSipProtocolError,
+    ArloSipTimeout,
+    AuthHeader,
+    SipMessage,
+    SipState,
+    build_ack_from_response,
+    build_bye_from_response,
+    build_invite,
+    build_message,
+)
+
+
+class _FakeArlo(object):
+    def debug(self, msg):
+        pass
+
+    def vdebug(self, msg):
+        pass
+
+
+class _FakeCamera(object):
+    device_id = "device-abc"
+    model_id = "VMC4070"
+    unique_id = "unique-abc"
+    xcloud_id = "xcloud-abc"
+
+
+class _FakeBackend(object):
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def get(self, path, params=None, headers=None, **kwargs):
+        self.calls.append({"path": path, "params": params, "headers": headers, "kwargs": kwargs})
+        return self.response
+
+
+class _FakeArloWithBackend(_FakeArlo):
+    def __init__(self, response):
+        self.be = _FakeBackend(response)
+
+
+class TestSipMessageParsing(TestCase):
+    def test_round_trip_request(self):
+        original = SipMessage("INVITE sip:callee@example.com SIP/2.0")
+        original.add_header("Via", "SIP/2.0/WSS abc.invalid;branch=z9hG4bK1234567")
+        original.add_header("Call-ID", "call-id-1")
+        original.add_header("CSeq", "1 INVITE")
+        original.body = "v=0\r\no=- 1 1 IN IP4 0.0.0.0\r\n"
+
+        parsed = SipMessage.parse(original.to_wire())
+
+        self.assertEqual(parsed.start_line, "INVITE sip:callee@example.com SIP/2.0")
+        self.assertEqual(parsed.get_header("Call-ID"), "call-id-1")
+        self.assertEqual(parsed.get_header("Via"), "SIP/2.0/WSS abc.invalid;branch=z9hG4bK1234567")
+        self.assertEqual(parsed.cseq_number, 1)
+        self.assertEqual(parsed.method, "INVITE")
+        self.assertEqual(parsed.body, "v=0\r\no=- 1 1 IN IP4 0.0.0.0\r\n")
+
+    def test_parse_response_status_and_method(self):
+        raw = (
+            "SIP/2.0 407 Proxy Authentication Required\r\n"
+            "Call-ID: call-id-1\r\n"
+            "CSeq: 1 INVITE\r\n"
+            "Proxy-Authenticate: Digest realm=\"arlo.com\", nonce=\"abc123\", algorithm=MD5, qop=\"auth\"\r\n"
+            "Content-Length: 0\r\n"
+            "\r\n"
+        )
+        message = SipMessage.parse(raw)
+        self.assertTrue(message.is_response)
+        self.assertEqual(message.status_code, 407)
+        self.assertEqual(message.method, "INVITE")
+        self.assertEqual(message.cseq_number, 1)
+
+    def test_content_length_truncates_trailing_frame_padding(self):
+        raw = "SIP/2.0 200 OK\r\nCall-ID: x\r\nCSeq: 1 INVITE\r\nContent-Length: 5\r\n\r\nv=0\r\ngarbage-after"
+        message = SipMessage.parse(raw)
+        self.assertEqual(message.body, "v=0\r\n")
+
+    def test_get_headers_returns_all_matches_in_order(self):
+        message = SipMessage("SIP/2.0 200 OK")
+        message.add_header("Record-Route", "<sip:a@proxy1>")
+        message.add_header("Record-Route", "<sip:b@proxy2>")
+        self.assertEqual(message.get_headers("record-route"), ["<sip:a@proxy1>", "<sip:b@proxy2>"])
+
+    def test_repeated_via_headers_survive_round_trip(self):
+        message = SipMessage("SIP/2.0 200 OK")
+        message.add_header("Via", "SIP/2.0/WSS host1.invalid;branch=b1")
+        message.add_header("Via", "SIP/2.0/WSS host2.invalid;branch=b2")
+        parsed = SipMessage.parse(message.to_wire())
+        self.assertEqual(len(parsed.get_headers("via")), 2)
+
+
+class TestAuthHeader(TestCase):
+    CHALLENGE = 'Digest realm="testrealm@host.com", nonce="dcd98b7102dd2f0e8b11d0f600bade7", algorithm=MD5, qop="auth", opaque="5ccc069c403ebaf9f0171e9517f40e41"'
+
+    def test_parse_extracts_all_params(self):
+        header = AuthHeader.parse(self.CHALLENGE)
+        self.assertEqual(header.mode, "Digest")
+        self.assertEqual(header.params["realm"], "testrealm@host.com")
+        self.assertEqual(header.params["nonce"], "dcd98b7102dd2f0e8b11d0f600bade7")
+        self.assertEqual(header.params["algorithm"], "MD5")
+        self.assertEqual(header.params["qop"], "auth")
+        self.assertEqual(header.params["opaque"], "5ccc069c403ebaf9f0171e9517f40e41")
+
+    def test_compute_response_matches_known_vector(self):
+        # RFC 2617-style vector, computed independently with the same
+        # ha1/ha2/response formula this implementation uses. cnonce/nc are
+        # generated when absent from the challenge, so pin them first.
+        header = AuthHeader.parse(self.CHALLENGE)
+        header.params["cnonce"] = "0a4f113b"
+        header.params["nc"] = "00000001"
+        response = header.compute_response(
+            method="GET",
+            uri="/dir/index.html",
+            username="Mufasa",
+            password="Circle Of Life",
+        )
+        self.assertEqual(response, "edb1d9656c02b946609ca3aa321bb910")
+
+    def test_compute_response_rejects_non_md5_algorithm(self):
+        header = AuthHeader.parse('Digest realm="r", nonce="n", algorithm=SHA-256, qop="auth"')
+        with self.assertRaises(ArloSipAuthError):
+            header.compute_response("INVITE", "sip:callee@x", "user", "pass")
+
+    def test_compute_response_rejects_missing_qop(self):
+        header = AuthHeader.parse('Digest realm="r", nonce="n"')
+        with self.assertRaises(ArloSipAuthError):
+            header.compute_response("INVITE", "sip:callee@x", "user", "pass")
+
+    def test_serialization_quotes_selectively(self):
+        header = AuthHeader("Digest", {
+            "username": "bob",
+            "realm": "arlo.com",
+            "nonce": "abc",
+            "uri": "sip:callee@x",
+            "response": "deadbeef",
+            "algorithm": "MD5",
+            "qop": "auth",
+            "nc": "00000001",
+            "cnonce": "xyz",
+        })
+        rendered = str(header)
+        self.assertTrue(rendered.startswith("Digest "))
+        # algorithm/qop/nc must be bare, everything else quoted.
+        self.assertIn("algorithm=MD5", rendered)
+        self.assertIn("qop=auth", rendered)
+        self.assertIn("nc=00000001", rendered)
+        self.assertIn('username="bob"', rendered)
+        self.assertIn('realm="arlo.com"', rendered)
+        self.assertIn('response="deadbeef"', rendered)
+        self.assertNotIn('algorithm="MD5"', rendered)
+        self.assertNotIn('qop="auth"', rendered)
+
+
+class TestBuildInvite(TestCase):
+    def test_header_shape(self):
+        message = build_invite(
+            caller_uri="sip:12345@sip.arlo.com:7443",
+            callee_uri="sip:device-abc@sip.arlo.com",
+            contact_host="abc123def456.invalid",
+            device_id="device-abc",
+            sdp="v=0\r\n",
+            user_agent="SIP.js/0.21.1",
+            call_id="call-id-1",
+            tag="tag1",
+            contact_user="contactuser",
+            cseq=1,
+            branch="z9hG4bK1234567",
+        )
+        self.assertEqual(message.start_line, "INVITE sip:device-abc@sip.arlo.com SIP/2.0")
+        self.assertEqual(message.get_header("Via"), "SIP/2.0/WSS abc123def456.invalid;branch=z9hG4bK1234567")
+        self.assertEqual(message.get_header("From"), '"WebRTC-UDP" <sip:12345@sip.arlo.com:7443>;tag=tag1')
+        self.assertEqual(message.get_header("To"), "<sip:device-abc@sip.arlo.com>")
+        self.assertEqual(message.get_header("Call-ID"), "call-id-1")
+        self.assertEqual(message.get_header("CSeq"), "1 INVITE")
+        self.assertEqual(message.get_header("Contact"), "<sip:contactuser@abc123def456.invalid;transport=ws;ob>")
+        self.assertEqual(message.get_header("X-extension"), "device-abc; User-Agent: webrtc")
+        self.assertEqual(message.get_header("Content-Type"), "application/sdp")
+        self.assertIsNone(message.get_header("Proxy-Authorization"))
+        self.assertEqual(message.body, "v=0\r\n")
+
+    def test_proxy_authorization_included_when_given(self):
+        message = build_invite(
+            caller_uri="sip:12345@sip.arlo.com:7443",
+            callee_uri="sip:device-abc@sip.arlo.com",
+            contact_host="abc123def456.invalid",
+            device_id="device-abc",
+            sdp="v=0\r\n",
+            user_agent="SIP.js/0.21.1",
+            call_id="call-id-1",
+            tag="tag1",
+            contact_user="contactuser",
+            cseq=2,
+            proxy_authorization='Digest username="12345", realm="arlo.com"',
+        )
+        self.assertEqual(message.get_header("CSeq"), "2 INVITE")
+        self.assertEqual(message.get_header("Proxy-Authorization"), 'Digest username="12345", realm="arlo.com"')
+
+
+class TestBuildAckAndBye(TestCase):
+    def _response(self):
+        response = SipMessage("SIP/2.0 200 OK")
+        response.add_header("Via", "SIP/2.0/WSS abc123def456.invalid;branch=z9hG4bK1234567")
+        response.add_header("From", '"WebRTC-UDP" <sip:12345@sip.arlo.com:7443>;tag=tag1')
+        response.add_header("To", "<sip:device-abc@sip.arlo.com>;tag=servertag")
+        response.add_header("Call-ID", "call-id-1")
+        response.add_header("CSeq", "1 INVITE")
+        response.add_header("Record-Route", "<sip:proxy1@sip.arlo.com;lr>")
+        response.add_header("Record-Route", "<sip:proxy2@sip.arlo.com;lr>")
+        return response
+
+    def test_ack_reuses_dialog_identifiers(self):
+        response = self._response()
+        ack = build_ack_from_response(response, "sip:device-abc@sip.arlo.com", "abc123def456.invalid", "SIP.js/0.21.1")
+
+        self.assertEqual(ack.start_line, "ACK sip:device-abc@sip.arlo.com SIP/2.0")
+        self.assertEqual(ack.get_header("Call-ID"), "call-id-1")
+        self.assertEqual(ack.get_header("From"), response.get_header("From"))
+        self.assertEqual(ack.get_header("To"), response.get_header("To"))
+        self.assertEqual(ack.get_header("CSeq"), "1 ACK")
+
+    def test_ack_reverses_record_route_into_route(self):
+        response = self._response()
+        ack = build_ack_from_response(response, "sip:device-abc@sip.arlo.com", "abc123def456.invalid", "SIP.js/0.21.1")
+        self.assertEqual(
+            ack.get_headers("Route"),
+            ["<sip:proxy2@sip.arlo.com;lr>", "<sip:proxy1@sip.arlo.com;lr>"],
+        )
+
+    def test_ack_uses_a_fresh_branch(self):
+        response = self._response()
+        ack = build_ack_from_response(response, "sip:device-abc@sip.arlo.com", "abc123def456.invalid", "SIP.js/0.21.1")
+        self.assertNotEqual(ack.get_header("Via"), response.get_header("Via"))
+        self.assertIn("abc123def456.invalid", ack.get_header("Via"))
+
+    def test_bye_increments_cseq_past_ack(self):
+        response = self._response()
+        bye = build_bye_from_response(response, "sip:device-abc@sip.arlo.com", "abc123def456.invalid", "SIP.js/0.21.1")
+        self.assertEqual(bye.start_line, "BYE sip:device-abc@sip.arlo.com SIP/2.0")
+        self.assertEqual(bye.get_header("CSeq"), "2 BYE")
+        self.assertEqual(bye.get_header("Call-ID"), "call-id-1")
+        self.assertEqual(bye.get_header("From"), response.get_header("From"))
+        self.assertEqual(bye.get_header("To"), response.get_header("To"))
+
+
+class TestBuildMessage(TestCase):
+    def test_keepalive_payload_and_content_type(self):
+        message = build_message(
+            "sip:12345@sip.arlo.com:7443", "sip:device-abc@sip.arlo.com", "abc123def456.invalid", "keepAlive", "SIP.js/0.21.1"
+        )
+        self.assertEqual(message.start_line, "MESSAGE sip:device-abc@sip.arlo.com SIP/2.0")
+        self.assertEqual(message.body, "keepAlive")
+        self.assertEqual(message.get_header("Content-Type"), "text/plain")
+        self.assertEqual(message.get_header("CSeq"), "1 MESSAGE")
+
+    def test_each_message_gets_a_fresh_dialog(self):
+        first = build_message("sip:c@x", "sip:d@x", "host.invalid", "keepAlive", "ua")
+        second = build_message("sip:c@x", "sip:d@x", "host.invalid", "keepAlive", "ua")
+        self.assertNotEqual(first.get_header("Call-ID"), second.get_header("Call-ID"))
+        self.assertNotEqual(first.get_header("From"), second.get_header("From"))
+
+
+class TestArloSipStateGuards(TestCase):
+    def _client(self):
+        return ArloSip(_FakeArlo(), _FakeCamera())
+
+    def test_ice_servers_empty_before_connect(self):
+        self.assertEqual(self._client().ice_servers, [])
+
+    def test_start_before_connect_raises(self):
+        with self.assertRaises(ArloSipError):
+            self._client().start("v=0\r\n")
+
+    def test_connect_twice_raises(self):
+        sip = self._client()
+        sip._state = SipState.CONNECTING  # pretend connect() already ran
+        with self.assertRaises(ArloSipError):
+            sip.connect()
+
+    def test_close_from_idle_is_a_safe_noop(self):
+        sip = self._client()
+        sip.close()
+        self.assertEqual(sip.state, SipState.CLOSED)
+        sip.close()  # idempotent - must not raise or re-run teardown
+        self.assertEqual(sip.state, SipState.CLOSED)
+
+
+class TestArloSipTransactionDispatch(TestCase):
+    """Exercises the reader-thread/queue correlation logic without a real socket."""
+
+    def test_dispatch_delivers_final_response_and_skips_provisional(self):
+        sip = ArloSip(_FakeArlo(), _FakeCamera())
+        message = build_message("sip:c@x", "sip:d@x", "host.invalid", "keepAlive", "ua")
+
+        def fake_send(msg):
+            # Stands in for the reader thread: deliver a provisional
+            # response first, then the final one - _send_and_wait must
+            # skip the former and return the latter.
+            trying = SipMessage("SIP/2.0 100 Trying")
+            trying.add_header("Call-ID", msg.get_header("Call-ID"))
+            trying.add_header("CSeq", msg.get_header("CSeq"))
+            sip._dispatch(trying)
+
+            accepted = SipMessage("SIP/2.0 202 Accepted")
+            accepted.add_header("Call-ID", msg.get_header("Call-ID"))
+            accepted.add_header("CSeq", msg.get_header("CSeq"))
+            sip._dispatch(accepted)
+
+        sip._send = fake_send
+        response = sip._send_and_wait(message, timeout=1)
+        self.assertEqual(response.status_code, 202)
+
+    def test_send_and_wait_times_out_with_no_response(self):
+        sip = ArloSip(_FakeArlo(), _FakeCamera())
+        sip._send = lambda msg: None
+        message = build_message("sip:c@x", "sip:d@x", "host.invalid", "keepAlive", "ua")
+        with self.assertRaises(ArloSipTimeout):
+            sip._send_and_wait(message, timeout=0.05)
+
+    def test_unmatched_response_is_dropped_not_raised(self):
+        sip = ArloSip(_FakeArlo(), _FakeCamera())
+        stray = SipMessage("SIP/2.0 200 OK")
+        stray.add_header("Call-ID", "nobody-is-waiting")
+        stray.add_header("CSeq", "1 INVITE")
+        sip._dispatch(stray)
+
+    def test_pending_transaction_cleaned_up_after_completion(self):
+        sip = ArloSip(_FakeArlo(), _FakeCamera())
+        message = build_message("sip:c@x", "sip:d@x", "host.invalid", "keepAlive", "ua")
+
+        def fake_send(msg):
+            accepted = SipMessage("SIP/2.0 202 Accepted")
+            accepted.add_header("Call-ID", msg.get_header("Call-ID"))
+            accepted.add_header("CSeq", msg.get_header("CSeq"))
+            sip._dispatch(accepted)
+
+        sip._send = fake_send
+        sip._send_and_wait(message, timeout=1)
+        self.assertEqual(sip._pending, {})
+
+
+class TestFetchSipInfo(TestCase):
+    """Regression coverage for the raw=True bug: sipInfo/v2 is wrapped in
+    Arlo's {"success": ..., "data": {...}} envelope, which pyaarlo's backend
+    unwraps automatically - UNLESS raw=True is passed, in which case
+    sipCallInfo silently ends up nested one level too deep and every SIP
+    session fails with a misleading "no sipInfo" error.
+    """
+
+    VALID_INFO = {
+        "sipCallInfo": {"id": "12345", "domain": "sip.arlo.com", "port": 5060, "calleeUri": "sip:d@x", "password": "p"},
+        "iceServers": {"data": []},
+    }
+
+    def test_does_not_request_raw_mode(self):
+        arlo = _FakeArloWithBackend(self.VALID_INFO)
+        sip = ArloSip(arlo, _FakeCamera())
+        sip._fetch_sip_info()
+        self.assertEqual(len(arlo.be.calls), 1)
+        self.assertNotIn("raw", arlo.be.calls[0]["kwargs"])
+
+    def test_accepts_already_unwrapped_response(self):
+        arlo = _FakeArloWithBackend(self.VALID_INFO)
+        sip = ArloSip(arlo, _FakeCamera())
+        result = sip._fetch_sip_info()
+        self.assertEqual(result, self.VALID_INFO)
+
+    def test_still_wrapped_response_raises_with_diagnostic_detail(self):
+        # What raw=True actually produced: sipCallInfo one level too deep.
+        wrapped = {"success": True, "data": self.VALID_INFO}
+        arlo = _FakeArloWithBackend(wrapped)
+        sip = ArloSip(arlo, _FakeCamera())
+        with self.assertRaises(ArloSipProtocolError) as ctx:
+            sip._fetch_sip_info()
+        self.assertIn(_FakeCamera.device_id, str(ctx.exception))
+        self.assertIn("success", str(ctx.exception))
+
+    def test_request_params_and_headers(self):
+        arlo = _FakeArloWithBackend(self.VALID_INFO)
+        sip = ArloSip(arlo, _FakeCamera())
+        sip._fetch_sip_info()
+        call = arlo.be.calls[0]
+        self.assertEqual(call["params"], {
+            "cameraId": "device-abc",
+            "modelId": "VMC4070",
+            "uniqueId": "unique-abc",
+        })
+        self.assertEqual(call["headers"], {"xcloudId": "xcloud-abc", "cameraId": "device-abc"})
+
+    def test_none_response_raises(self):
+        arlo = _FakeArloWithBackend(None)
+        sip = ArloSip(arlo, _FakeCamera())
+        with self.assertRaises(ArloSipProtocolError):
+            sip._fetch_sip_info()
+
+
+class TestFetchInfoIsRestOnly(TestCase):
+    """`fetch_info()` must stay REST-only.
+
+    Callers need `ice_servers` before they can build an offer, and the gap
+    between the two is however long their peer connection takes to gather
+    ICE candidates. If fetching the credentials also opened the websocket,
+    every caller would be holding an idle socket across that window - which
+    is exactly what Home Assistant does between `get_client_config` and
+    `offer`.
+    """
+
+    INFO = {
+        "sipCallInfo": {
+            "id": "12345",
+            "domain": "sip.arlo.com",
+            "port": 5060,
+            "calleeUri": "sip:d@x",
+            "password": "p",
+        },
+        "iceServers": {
+            "data": [
+                {"type": "stun", "domain": "stun.arlo.com", "port": 3478},
+                {
+                    "type": "turn",
+                    "domain": "turn.arlo.com",
+                    "port": 443,
+                    "username": "u",
+                    "credential": "c",
+                },
+            ]
+        },
+    }
+
+    def _sip(self):
+        return ArloSip(_FakeArloWithBackend(self.INFO), _FakeCamera())
+
+    def test_leaves_state_idle_and_websocket_unopened(self):
+        sip = self._sip()
+        sip.fetch_info()
+        self.assertEqual(sip.state, SipState.IDLE)
+        self.assertIsNone(sip._ws)
+
+    def test_populates_ice_servers(self):
+        sip = self._sip()
+        sip.fetch_info()
+        self.assertEqual(sip.ice_servers, [
+            {"urls": ["stun:stun.arlo.com:3478"], "username": None, "credential": None},
+            {"urls": ["turn:turn.arlo.com:443"], "username": "u", "credential": "c"},
+        ])
+
+    def test_derives_the_sip_uris(self):
+        sip = self._sip()
+        sip.fetch_info()
+        self.assertEqual(sip._username, "12345")
+        self.assertEqual(sip._password, "p")
+        self.assertEqual(sip._caller_uri, "sip:12345@sip.arlo.com:7443")
+        self.assertEqual(sip._callee_uri, "sip:d@x")
+
+    def test_is_idempotent(self):
+        sip = self._sip()
+        sip.fetch_info()
+        sip.fetch_info()
+        self.assertEqual(len(sip._arlo.be.calls), 1)
+
+    def test_a_failed_fetch_does_not_poison_the_cache(self):
+        sip = ArloSip(_FakeArloWithBackend(None), _FakeCamera())
+        with self.assertRaises(ArloSipProtocolError):
+            sip.fetch_info()
+        self.assertIsNone(sip._sip_info)
+
+    def test_ensure_connected_is_a_noop_once_connecting(self):
+        sip = self._sip()
+        sip._set_state(SipState.CONNECTING)
+        sip.ensure_connected()
+        self.assertIsNone(sip._ws)


### PR DESCRIPTION
## Summary

Adds support for the SIP/WebRTC protocol that Arlo's official apps (including my.arlo.com in a browser) actually use for live view — until now pyaarlo only spoke the RTSPS path via `startStream`. The two engines are mutually exclusive on a given camera (Arlo returns *"SIP Streaming in progress, RTSP Streaming is not allowed"* if you try both at once).

**Important: this is signaling only.** pyaarlo negotiates the SDP offer/answer exchange over SIP-over-WebSocket, but never creates an `RTCPeerConnection` and never touches a media packet. The caller must supply their own WebRTC stack (browser, `aiortc`, `go2rtc`, ...) to build the offer and play the answer.

## What's added

- **`pyaarlo/sip.py`** (new, ~735 lines) — dedicated SIP-over-WebSocket client: SIP message parsing/building (INVITE/ACK/MESSAGE/BYE), MD5 digest authentication (`qop=auth`), a state machine (`IDLE → CONNECTING → AUTHENTICATING → ESTABLISHED → CLOSING/CLOSED/FAILED`), a dedicated reader thread plus a keepalive thread. Deliberately not a general-purpose SIP stack — only the message subset Arlo's proxy expects is handled.
- **`pyaarlo/sdp.py`** (new) — pure, I/O-free SDP repair functions:
  - `filter_offer_candidates`: strips IPv6 and mDNS `.local` ICE candidates that Arlo's proxy silently rejects (the INVITE goes through but negotiation fails).
  - `clean_answer`: Arlo omits `a=mid` and direction attributes on its SDP answers, which most WebRTC stacks (Chrome included) reject outright — these helpers reinsert them, and also strip `a=end-of-candidates`, which Chrome also rejects.
- **`pyaarlo/capabilities.py`** (new) — fetches and caches (in-memory + `arlo.st`, 24h TTL) the capability document Arlo publishes per model/interface-version, to determine whether a camera supports SIP streaming (`supports_sip_streaming`) and SIP push-to-talk (`supports_sip_push_to_talk`). Falls back to a hardcoded model list (known incomplete) if the document can't be fetched — a failure here must never block RTSPS.
- **`pyaarlo/camera.py`** — new public API on `ArloCamera`:
  - `get_sip_info()`: opens the signaling session (REST only, doesn't open the websocket yet) and returns the `ice_servers` Arlo published, to be used when building the offer.
  - `start_sip_stream(offer_sdp)`: negotiates the call (INVITE → digest auth on a 407 challenge → ACK) and returns the repaired answer SDP.
  - `stop_sip_stream()`: cleanly tears down the session (BYE if established).
  - `supports_sip_streaming`, `supports_sip_push_to_talk`, `stream_protocols` (new properties).
  - `is_streaming` now also covers the SIP path.
- **`pyaarlo/device.py`** — new `interface_version` and `capabilities` properties on `ArloDevice`.
- **`pyaarlo/cfg.py`** — new config kwargs: `sip_timeout` (5s), `sip_keepalive` (30s), `sip_user_agent`, `sip_ws_port` (7443).
- **`pyaarlo/main.py`** — new CLI commands: `pyaarlo camera <name> sip-info` (diagnostic: does this camera respond to SIP at all?) and `start-sip-stream --offer-file ... [--answer-file ...]`, plus `pyaarlo capabilities`.
- **`examples/sip-stream`** — runnable end-to-end script demonstrating the signaling handshake.
- **`README.md`** — new "SIP/WebRTC Streaming" section documenting usage and limitations.
- **`requirements.txt` / `setup.py`** — adds the `websocket-client` dependency, bumps version `0.8.0.22` → `0.8.0.23`.

## Tests

- `tests/test_sdp.py` (16 tests) — covers ICE candidate filtering, `a=mid`/direction insertion, `a=end-of-candidates` removal, and the CRLF line-termination edge cases that were crashing Chrome's SDP parser.
- `tests/test_sip_messages.py` (37 tests) — SIP message parsing/round-trip, digest computation (RFC 2617 test vector), INVITE/ACK/BYE/MESSAGE construction, the state machine, response correlation by the reader thread, and a targeted regression for a REST envelope bug (`sipInfo/v2` is wrapped in `{"success", "data"}` — accidentally passing `raw=True` silently broke every session).

## Out of scope

- No media handling (no `aiortc`, no playing/recording the SIP stream) — deliberate, see the `ArloSip` docstring.
- Full-duplex push-to-talk (`has_full_duplex_push_to_talk` in `capabilities.py`) is detected but not yet wired to a camera action.